### PR TITLE
change `Nectar OS` -> NectarOS`

### DIFF
--- a/src/apis/http_authentication.md
+++ b/src/apis/http_authentication.md
@@ -1,6 +1,6 @@
 # HTTP API
 
-In Nectar OS, incoming HTTP requests are handled by a Rust `warp` server in the core `http_server:sys:nectar` process.
+In NectarOS, incoming HTTP requests are handled by a Rust `warp` server in the core `http_server:sys:nectar` process.
 This process handles binding (registering) routes, simple JWT-based authentication, and serving a `/login` page if auth is missing.
 
 ## Binding (Registering) HTTP Paths

--- a/src/apis/websocket_authentication.md
+++ b/src/apis/websocket_authentication.md
@@ -1,6 +1,6 @@
 # WebSocket API
 
-In Nectar OS, WebSocket connects are made with a Rust `warp` server in the core `http_server:sys:nectar` process.
+In NectarOS, WebSocket connects are made with a Rust `warp` server in the core `http_server:sys:nectar` process.
 Each connection is assigned a `channel_id` that can be bound to a given process using a `WsRegister` message.
 The process receives the `channel_id` for pushing data into the WebSocket, and any subsequent messages from that client will be forwarded to the bound process.
 

--- a/src/chess_app/chess_engine.md
+++ b/src/chess_app/chess_engine.md
@@ -1,6 +1,6 @@
 # In-Depth Guide: Chess App
 
-This guide will walk you through building a very simple chess app on Nectar OS.
+This guide will walk you through building a very simple chess app on NectarOS.
 The final result will look like [this](https://github.com/uqbar-dao/nectar/tree/main/modules/chess): chess is in the basic runtime distribution so you can try it yourself.
 
 To prepare for this tutorial, follow the environment setup guide [here](../my_first_app/chapter_1.md), i.e. [start a fake node](../my_first_app/chapter_1.md#booting-a-fake-nectar-node) and then, in another terminal, run:

--- a/src/chess_app/putting_everything_together.md
+++ b/src/chess_app/putting_everything_together.md
@@ -26,7 +26,7 @@ If you're interested in learning more about how to write Nectar processes, there
 - Consider what another app might look like that uses the chess engine as a library.
 Alter the process to serve this use case, or add another process that can be spawned to do such a thing.
 
-There are also three extensions to this tutorial which dive into specific use cases which make the most of Nectar OS:
+There are also three extensions to this tutorial which dive into specific use cases which make the most of NectarOS:
 
 - [Chat](./chat.md)
 - [Payment Integration (using ETH)](./payment.md)

--- a/src/cookbook/manage_child_processes.md
+++ b/src/cookbook/manage_child_processes.md
@@ -1,6 +1,6 @@
 # Spawning and Managing Child Processes
 
-In Nectar OS, a "parent" process can create additional processes, known as "children".
+In NectarOS, a "parent" process can create additional processes, known as "children".
 These child processes are particularly useful for handling intensive tasks (referred to as "workers") that require long computation times without hindering the performance of the main application.
 They are also beneficial for segregating distinct logical components.
 Each process is its own subdirectory within the package.

--- a/src/design_philosophy.md
+++ b/src/design_philosophy.md
@@ -1,5 +1,5 @@
 # Design Philosophy
-The following is a high-level overview of Nectar OS's design philosophy, along with the rationale for fundamental design choices.
+The following is a high-level overview of NectarOS's design philosophy, along with the rationale for fundamental design choices.
 
 ### Decentralized Software Requires a Shared Computing Environment
 A single shared computing environment enables software to coordinate directly between users, services, and other pieces of software in a common language.

--- a/src/frontends.md
+++ b/src/frontends.md
@@ -1,6 +1,6 @@
 # Frontends
 
-Nectar OS can easily serve any webpage or web app developed with normal libraries and frameworks.
+NectarOS can easily serve any webpage or web app developed with normal libraries and frameworks.
 
 There are some specific endpoints, JS libraries, and process lib functions that are helpful for doing frontend development.
 

--- a/src/identity_system.md
+++ b/src/identity_system.md
@@ -2,7 +2,7 @@
 
 One of the most important features of a peer-to-peer network is the ability to maintain a unique and persistent identity.
 This identity must be self-sovereign, unforgeable, and easy to discover by peers.
-Nectar OS uses a domain system similar to [ENS](https://ens.domains/) to achieve this.
+NectarOS uses a domain system similar to [ENS](https://ens.domains/) to achieve this.
 It should be noted that, in our system, the concepts of `domain`, `identity`, and `username` are identical and interchangeable.
 
 Like ENS, Nectar domains (managed by our QNS) are registered by a wallet and owned in the form of an NFT.

--- a/src/install.md
+++ b/src/install.md
@@ -1,6 +1,6 @@
 # Installation
 
-This section will teach you how to get the Nectar OS core software, required to run a live node.
+This section will teach you how to get the NectarOS core software, required to run a live node.
 After acquiring the software, you can learn how to run it and [Join the Network](./login.md).
 However, if you are just interested in starting development as fast as possible, start with [My First Nectar Application](./my_first_app/chapter_1.md).
 
@@ -42,7 +42,7 @@ cargo install cargo-wasi
 
 For more information, or debugging, see the [Rust lang install page](https://www.rust-lang.org/tools/install).
 
-### Acquire Nectar OS core
+### Acquire NectarOS core
 
 Clone and set up the repository:
 

--- a/src/intro.md
+++ b/src/intro.md
@@ -6,7 +6,7 @@ The Nectar Book describes the Nectar operating system, both in conceptual and pr
 * To learn about high-level concepts, keep reading these documents in-order.
 * To learn about how the system functions, start reading about [System Components](./processes.md).
 
-Nectar OS is a decentralized operating system, peer-to-peer app framework, and node network designed to simplify the development and deployment of decentralized applications.
+NectarOS is a decentralized operating system, peer-to-peer app framework, and node network designed to simplify the development and deployment of decentralized applications.
 It is also a *sovereign cloud computer*, in that Nectar can be deployed anywhere and act as a server controlled by anyone.
 Ultimately, Nectar facilitates the writing and distribution of software that runs on privately-held, personal server nodes or node clusters.
 
@@ -19,7 +19,7 @@ Identity         | Linking permanent system-wide identities to individual nodes.
 Data Persistence | Storing data and saving it in perpetuity.
 Global State     | Reading shared global state (blockchain) and composing actions with this state (transactions).
 
-The focus of this book is how to build and deploy applications on Nectar OS.
+The focus of this book is how to build and deploy applications on NectarOS.
 
 ## Architecture Overview
 
@@ -28,7 +28,7 @@ Nectar's kernel handles the startup and teardown of processes, as well as messag
 Processes are programs compiled to Wasm, which export a single `init()` function.
 They can be started once and complete immediately, or they can run "forever".
 
-Peers in Nectar OS are identified by their onchain username in the "QNS": uQbar Name System, which is modeled after ENS.
+Peers in NectarOS are identified by their onchain username in the "QNS": uQbar Name System, which is modeled after ENS.
 The modular architecture of the QNS allows for any Ethereum NFT, including ENS names themselves, to generate a unique Nectar identity once it is linked to a QNS entry.
 
 Data persistence and blockchain access, as fundamental primitives for p2p apps, are built directly into the kernel.

--- a/src/login.md
+++ b/src/login.md
@@ -2,7 +2,7 @@
 
 Let's get onto the live network!
 
-These directions are particular to the Nectar OS alpha release.
+These directions are particular to the NectarOS alpha release.
 Joining the network will become significantly easier on subsequent releases.
 
 Note: While Nectar will eventually post identities to Optimism, the alpha release uses the Ethereum Sepolia testnet.

--- a/src/my_first_app/chapter_1.md
+++ b/src/my_first_app/chapter_1.md
@@ -17,7 +17,7 @@ The application will be a simple chat interface: `my_chat_app`.
 
 The following assumes a Unix environment — macOS or Linux.
 If on Windows, [get WSL](https://learn.microsoft.com/en-us/windows/wsl/install) first.
-In general, Nectar OS does not support Windows.
+In general, NectarOS does not support Windows.
 
 ## Acquiring Rust and the Nectar Development Tools (`uqdev`)
 

--- a/src/my_first_app/chapter_2.md
+++ b/src/my_first_app/chapter_2.md
@@ -77,7 +77,7 @@ fn my_init_fn(our: Address) {
 ```
 
 See [nectar.wit](./apis/nectar_wit.md) for more details on what is imported by the WIT bindgen macro.
-These imports are the necessary "system calls" for talking to other processes and runtime components in Nectar OS.
+These imports are the necessary "system calls" for talking to other processes and runtime components in NectarOS.
 
 Run
 ```bash

--- a/src/my_first_app/chapter_3.md
+++ b/src/my_first_app/chapter_3.md
@@ -50,7 +50,7 @@ This comes with a number of benefits:
 
 Defining IPC types is just one step towards writing interoperable code.
 It's also critical to document the overall structure of the program along with message payloads and metadata used, if any.
-Writing interoperable code is necessary for enabling permissionless composability, and Nectar OS aims to make this the default kind of program, unlike the centralized web.
+Writing interoperable code is necessary for enabling permissionless composability, and NectarOS aims to make this the default kind of program, unlike the centralized web.
 
 First, let's create a request that uses the new IPC type (and stop expecting a response):
 ```rust

--- a/src/process-capabilities.md
+++ b/src/process-capabilities.md
@@ -2,7 +2,7 @@
 Capabilities are a security paradigm in which an ability that is usually handled as a *permission* (i.e. certain processes are allowed to perform an action if they are saved on an "access control list") are instead handled as a *token* (i.e. the process that possesses token can perform a certain action).
 These unforgeable tokens (as enforced by the kernel) can be passed to other owners, held by a given process, and checked for.
 
-In Nectar OS, each process has an associated set of capabilities, which are each represented internally as an arbitrary JSON object with a source process:
+In NectarOS, each process has an associated set of capabilities, which are each represented internally as an arbitrary JSON object with a source process:
 
 ```rust
 pub struct Capability {

--- a/src/process-startup.md
+++ b/src/process-startup.md
@@ -13,7 +13,7 @@ There are two ways: either the process can use the built-in `set_state` and `get
 
 The first option is a maximally-simple way to write some bytes to disk (where they'll be backed up, if the node owner has configured that behavior).
 The second option is vastly more general, because runtime modules that have direct messaging availability from userspace offer any number of APIs.
-So far, there are three modules built into Nectar OS that are designed for persisted data: a [filesystem](./files.md), a [key-value store, and a SQLite database](./databases.md).
+So far, there are three modules built into NectarOS that are designed for persisted data: a [filesystem](./files.md), a [key-value store, and a SQLite database](./databases.md).
 
 Each of these modules offer APIs accessed via message-passing and write data to disk.
 Between instantiations of a process, this data remains saved, even backed up.

--- a/src/process_stdlib/overview.md
+++ b/src/process_stdlib/overview.md
@@ -1,6 +1,6 @@
 # Overview
 
-The [process standard library](https://github.com/uqbar-dao/process_lib) is the easiest way to write Rust apps on Nectar OS.
+The [process standard library](https://github.com/uqbar-dao/process_lib) is the easiest way to write Rust apps on NectarOS.
 
 Since Nectar apps use the [WebAssembly Component Model](https://component-model.bytecodealliance.org/), they are built on top of a WIT (Wasm Interface Type) package.
 This interface contains the core types and functions that are available to all Nectar apps, and these are automatically generated in Rust when building a Wasm app.

--- a/src/processes.md
+++ b/src/processes.md
@@ -2,7 +2,7 @@
 
 ### Overview
 
-On Nectar OS, processes are the building blocks for peer-to-peer applications.
+On NectarOS, processes are the building blocks for peer-to-peer applications.
 The Nectar runtime handles message-passing between processes, plus the startup and teardown of said processes.
 This section describes the message design as it relates to processes.
 


### PR DESCRIPTION
I realized there should probably not be a space between `Nectar` and `OS` when they appear together.