### PR TITLE
Update install.md

### DIFF
--- a/src/install.md
+++ b/src/install.md
@@ -48,7 +48,7 @@ For more information, or debugging, see the [Rust lang install page](https://www
 Clone and set up the repository:
 
 ```bash
-git clone git@github.com:kinode-dao/kinode.git
+git clone https://github.com/kinode-dao/kinode.git
 ```
 
 Build the binary:


### PR DESCRIPTION
Changed:

git clone git@github.com:kinode-dao/kinode.git

To:

git clone https://github.com/kinode-dao/kinode.git

As the prior triggered a: "WARNING: REMOTE HOST IDENTIFICATION HAS CHANGED!" message from my terminal