### PR TITLE
Hyperlinks in Getting Started

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -30,7 +30,7 @@
   - [`inject-message`](./kit/inject-message.md)
   - [`run-tests`](./kit/run-tests.md)
   - [`reset-cache`](./kit/reset-cache.md)
-- [Tutorial: Build and Deploy an App](./build-and-deploy-an-app.md)
+- [My First Kinode Application](./build-and-deploy-an-app.md)
   - [Environment Setup](./my_first_app/chapter_1.md)
   - [Sending Some Messages, Using Some Tools](./my_first_app/chapter_2.md)
   - [Defining Your Protocol](./my_first_app/chapter_3.md)

--- a/src/build-and-deploy-an-app.md
+++ b/src/build-and-deploy-an-app.md
@@ -1,4 +1,4 @@
-# Tutorial: Build and Deploy an App
+# My First Kinode Application
 
 Welcome!
 In these tutorials, you'll setup your development environment and learn about the `kit` tools.

--- a/src/install.md
+++ b/src/install.md
@@ -2,7 +2,7 @@
 
 This section will teach you how to get the Kinode OS core software, required to run a live node.
 After acquiring the software, you can learn how to run it and [Join the Network](./login.md).
-However, if you are just interested in starting development as fast as possible, start with [My First Kinode Application](./my_first_app/chapter_1.md).
+However, if you are just interested in starting development as fast as possible, start with [My First Kinode Application](./build-and-deploy-an-app.md).
 
 If you want to make edits to the Kinode core software, see [Build From Source](#build-from-source).
 

--- a/src/kit/install.md
+++ b/src/kit/install.md
@@ -36,7 +36,7 @@ or for any of the subcommands, e.g.:
 kit new --help
 ```
 
-The first chapter of the [Build and Deploy an App tutorial](../my_first_app/chapter_1.md) shows the `kit` tools in action.
+The first chapter of the [My First Kinode App tutorial](../my_first_app/chapter_1.md) shows the `kit` tools in action.
 
 ## Getting kit
 

--- a/src/quick-start.md
+++ b/src/quick-start.md
@@ -7,7 +7,7 @@ A more detailed version of this Quick Start leads off the [My First Kinode Appli
 
 Otherwise:
 * To learn about high-level concepts, start with the [Introduction](./intro.md), and work through the book in-order.
-* To learn about how the system functions, start reading about [System Components](./process/processes.md).
+* To learn about how the system functions, start reading about [System Components](./system-components.md).
 
 ## Run two fake Kinodes and chat between them
 

--- a/src/quick-start.md
+++ b/src/quick-start.md
@@ -3,7 +3,7 @@
 Kinode OS is a decentralized operating system, peer-to-peer app framework, and node network designed to simplify the development and deployment of decentralized applications.
 
 This Quick Start page is targeted at developers: if you want to get your hands dirty, continue [below](#run-two-fake-kinodes-and-chat-between-them).
-A more detailed version of this Quick Start leads off the [My First Kinode Application](./my_first_app/chapter_1.md) section.
+A more detailed version of this Quick Start leads off the [My First Kinode Application](./build-and-deploy-an-app.md) section.
 
 Otherwise:
 * To learn about high-level concepts, start with the [Introduction](./intro.md), and work through the book in-order.
@@ -47,7 +47,7 @@ m our@my_chat_app:my_chat_app:template.os '{"Send": {"target": "fake.os", "messa
 
 ## Next steps
 
-The first chapter of the [My First Kinode Application](./my_first_app/chapter_1.md) tutorial is a more detailed version of this Quick Start.
+The first chapter of the [My First Kinode Application](./build-and-deploy-an-app.md) tutorial is a more detailed version of this Quick Start.
 Alternatively, you can learn more about `kit` in the [`kit` documentation](./kit-dev-toolkit.md).
 
 If instead, you want to learn more about high-level concepts, start with the [Introduction](./intro.md) and work your way through the book in-order.


### PR DESCRIPTION
- renamed 'Tutorial: Build and Deploy an App' to 'My First Kinode Application' as that's how it was referenced throughout Getting Started
- fixed hyperlinks which pointed to the first page in the section rather than the overview of the section. E.g. 'My First Kinode Application' link pointing to 'Environment Setup' page rather than 'My First Kinode Application' page