### PR TITLE
Section 2.5. Read and Write to Chain

### DIFF
--- a/src/read_and_write_to_chain.md
+++ b/src/read_and_write_to_chain.md
@@ -1,7 +1,7 @@
 # Read+Write to Chain
 
 Kinode OS comes with a built-in provider layer for Ethereum and other EVM chains/rollups.
-This runtime module lives in `eth:distro:sys` and is usable by any package which acquires the messaging capability for it.
+This runtime module lives in [`eth:distro:sys`](https://github.com/kinode-dao/kinode/tree/main/kinode/src/eth) and is usable by any package which acquires the messaging capability for it.
 In addition to allowing connections directly to WebSocket RPC endpoints, the provider can also connect via the Kinode networking protocol to other Kinodes and use their provider as a relay.
 The node must be configured to allow relay connections, which can be done with a public/private flag or explicit allow/deny list.
 

--- a/src/read_and_write_to_chain.md
+++ b/src/read_and_write_to_chain.md
@@ -1,24 +1,24 @@
 # Read+Write to Chain
 
 Kinode OS comes with a built-in provider module for Ethereum and other EVM chains/rollups.
-This runtime module lives in [`eth:distro:sys`](https://github.com/kinode-dao/kinode/tree/main/kinode/src/eth) and is usable by any package which acquires the messaging capability for it.
-In addition to allowing connections directly to WebSocket RPC endpoints, the provider can also connect via the Kinode networking protocol to other Kinodes and use their provider as a relay to an RPC endpoint (or to another Kinode, forming a relay chain).
+This runtime module lives in [`eth:distro:sys`](https://github.com/kinode-dao/kinode/tree/main/kinode/src/eth) and is usable by any package that acquires the messaging capability for it.
+In addition to allowing read/write connections directly to WebSocket RPC endpoints, the provider module can also connect via the Kinode networking protocol to other Kinodes and use their provider modules as a relay to an RPC endpoint (or to another Kinode, forming a relay chain).
 The node must be configured to allow relay connections, which can be done with a public/private flag or explicit allow/deny list.
 
-As with other runtime modules, processes should generally use the [kinode_process_lib](https://github.com/kinode-dao/process_lib) to interact with the provider.
+As with other runtime modules, processes should generally use the [kinode_process_lib](https://github.com/kinode-dao/process_lib) to interact with the RPC provider.
 See [Reading Data from ETH](./cookbook/reading_data_from_eth.md) for an example of doing this in a process.
-For more advanced or direct usage, such as configuring the provider, see the [API Reference](./apis/eth_provider.md).
+For more advanced or direct usage, such as configuring the provider module, see the [API Reference](./apis/eth_provider.md).
 
 ### Supported Chains
 
-The provider is capable of using any RPC endpoint that follows the [JSON-RPC API](https://ethereum.org/developers/docs/apis/json-rpc) that is used by Ethereum and most other EVM chains and rollups.
+The provider module is capable of using any RPC endpoint that follows the [JSON-RPC API](https://ethereum.org/developers/docs/apis/json-rpc) that is used by Ethereum and most other EVM chains and rollups.
 The runtime uses the [Alloy](https://github.com/alloy-rs) family of libraries to connect to WS RPC endpoints.
 It does not currently support HTTP endpoints, as subscriptions are vastly preferable for many of the features that Kinode OS uses.
 
 ### Configuration
 
 The [API Reference](./apis/eth_provider.md) demonstrates how to format requests to `eth:distro:sys` that adjust its config during runtime.
-This includes adding and removing providers and adjusting the permissions for other nodes to use this node as a relay.
+This includes adding and removing providers (whether other Kinodes or chain RPCs) and adjusting the permissions for other nodes to use this node as a relay.
 However, most configuration is done in an optional file named `.eth-providers` inside the home folder of a node.
 If this file is not present, a node will boot using the default providers hardcoded for testnet or mainnet, depending on where the node lives.
 If it is present, the node will load in those providers and use them.
@@ -56,7 +56,7 @@ The file is a JSON object: a list of providers, with the following shape (exampl
 
 One can see that the provider list includes both node-providers (other Kinodes that are permissioned for use as a relay) and url-providers (traditional RPC endpoints).
 Nodes that wish to maximize their connectivity should supply themselves with url-providers, ideally trusted ones—they can even be running locally, with a light client for Ethereum such as [Helios](https://github.com/a16z/helios).
-In fact, a future update to the provider will likely integrate Helios, which will allow nodes to convert untrusted endpoints to trusted ones. This is the reason for the `trusted` flag in the provider object.
+In fact, a future update to the provider module will likely integrate Helios, which will allow nodes to convert untrusted endpoints to trusted ones. This is the reason for the `trusted` flag in the provider object.
 
 Lastly, note that the `kns_update` object must fully match the onchain PKI data for the given node, otherwise the two nodes will likely not be able to establish a connection.
 

--- a/src/read_and_write_to_chain.md
+++ b/src/read_and_write_to_chain.md
@@ -1,8 +1,8 @@
 # Read+Write to Chain
 
-Kinode OS comes with a built-in provider layer for Ethereum and other EVM chains/rollups.
+Kinode OS comes with a built-in provider module for Ethereum and other EVM chains/rollups.
 This runtime module lives in [`eth:distro:sys`](https://github.com/kinode-dao/kinode/tree/main/kinode/src/eth) and is usable by any package which acquires the messaging capability for it.
-In addition to allowing connections directly to WebSocket RPC endpoints, the provider can also connect via the Kinode networking protocol to other Kinodes and use their provider as a relay.
+In addition to allowing connections directly to WebSocket RPC endpoints, the provider can also connect via the Kinode networking protocol to other Kinodes and use their provider as a relay to an RPC endpoint (or to another Kinode, forming a relay chain).
 The node must be configured to allow relay connections, which can be done with a public/private flag or explicit allow/deny list.
 
 As with other runtime modules, processes should generally use the [kinode_process_lib](https://github.com/kinode-dao/process_lib) to interact with the provider.
@@ -22,7 +22,7 @@ This includes adding and removing providers and adjusting the permissions for ot
 However, most configuration is done in an optional file named `.eth-providers` inside the home folder of a node.
 If this file is not present, a node will boot using the default providers hardcoded for testnet or mainnet, depending on where the node lives.
 If it is present, the node will load in those providers and use them.
-The file is a JSON object with the following shape (example data):
+The file is a JSON object: a list of providers with the following shape (example data):
 
 ```json
 [
@@ -55,7 +55,7 @@ The file is a JSON object with the following shape (example data):
 ```
 
 One can see that the provider list includes both node-providers (other Kinodes that are permissioned for use as a relay) and url-providers (traditional RPC endpoints).
-Nodes that wish to maximize their connectivity should supply themselves with url-providers, ideally trusted ones—they can even be running locally, with a light client such as [Helios](https://github.com/a16z/helios).
+Nodes that wish to maximize their connectivity should supply themselves with url-providers, ideally trusted ones—they can even be running locally, with a light client for Ethereum such as [Helios](https://github.com/a16z/helios).
 In fact, a future update to the provider will likely integrate Helios, which will allow nodes to convert untrusted endpoints to trusted ones. This is the reason for the `trusted` flag in the provider object.
 
 Lastly, note that the `kns_update` object must fully match the onchain PKI data for the given node, otherwise the two nodes will likely not be able to establish a connection.

--- a/src/read_and_write_to_chain.md
+++ b/src/read_and_write_to_chain.md
@@ -22,7 +22,7 @@ This includes adding and removing providers and adjusting the permissions for ot
 However, most configuration is done in an optional file named `.eth-providers` inside the home folder of a node.
 If this file is not present, a node will boot using the default providers hardcoded for testnet or mainnet, depending on where the node lives.
 If it is present, the node will load in those providers and use them.
-The file is a JSON object: a list of providers with the following shape (example data):
+The file is a JSON object: a list of providers, with the following shape (example data):
 
 ```json
 [


### PR DESCRIPTION
1. 'In addition to allowing connections directly to WebSocket RPC endpoints'
 - this is both read/write, correct?
 - RPC endpoints is referring specifically to endpoints of EVM based chains? I assume things like infura, alchemy, ... fall under this category, but e.g. chainlink (which provide a bunch of offchain stuff) doesn't. 

2. the word 'provider' seems to be referring to two things
 - runtime module
 - chain access provider
 is there another word for the latter so we could disambiguate it?