### PR TITLE
Section 2.6. Files

### DIFF
--- a/src/files.md
+++ b/src/files.md
@@ -3,7 +3,7 @@
 ## Virtual File System (VFS)
 
 The primary way to access files within your node is through the [VFS API](./apis/vfs.md).
-The VFS API follows [std::fs](https://doc.rust-lang.org/std/fs/index.html) closely, adding some capabilities checks on paths and some combinatory actions.
+The VFS API follows [std::fs](https://doc.rust-lang.org/std/fs/index.html) closely, while also adding some capabilities checks on paths.
 
 VFS files exist in the "/vfs" folder within your home node, and files are grouped by [`package_id`](https://docs.rs/kinode_process_lib/latest/kinode_process_lib/struct.PackageId.html).
 For example, part of the VFS might look like:

--- a/src/files.md
+++ b/src/files.md
@@ -3,7 +3,7 @@
 ## Virtual File System (VFS)
 
 The primary way to access files within your node is through the [VFS API](./apis/vfs.md).
-The VFS API follows std::fs closely, adding some capabilities checks on paths and some combinatory actions.
+The VFS API follows [std::fs](https://doc.rust-lang.org/std/fs/index.html) closely, adding some capabilities checks on paths and some combinatory actions.
 
 VFS files exist in the "/vfs" folder within your home node, and files are grouped by `package_id`.
 For example, part of the VFS might look like:

--- a/src/files.md
+++ b/src/files.md
@@ -43,8 +43,3 @@ let test_file = create_file(&format("{}/test.txt", &drive_path))?;
 let text = b"hello world!"
 file.write(&text)?;
 ```
-
-## References
-
-- [VFS API](./apis/vfs.md)
-- [std::fs API](https://doc.rust-lang.org/std/fs/index.html)

--- a/src/files.md
+++ b/src/files.md
@@ -5,7 +5,7 @@
 The primary way to access files within your node is through the [VFS API](./apis/vfs.md).
 The VFS API follows [std::fs](https://doc.rust-lang.org/std/fs/index.html) closely, adding some capabilities checks on paths and some combinatory actions.
 
-VFS files exist in the "/vfs" folder within your home node, and files are grouped by `package_id`.
+VFS files exist in the "/vfs" folder within your home node, and files are grouped by [`package_id`](https://docs.rs/kinode_process_lib/latest/kinode_process_lib/struct.PackageId.html).
 For example, part of the VFS might look like:
 
 ```text
@@ -33,7 +33,7 @@ For example, part of the VFS might look like:
 
 ## Usage
 
-To access files in the VFS, you need to create or open a [drive](./apis/vfs.md#drives), this can be done with the function `create_drive` from the [standard library](./process_stdlib/overview.md):
+To access files in the VFS, you need to create or open a [drive](./apis/vfs.md#drives), this can be done with the function [`create_drive`](https://docs.rs/kinode_process_lib/latest/kinode_process_lib/vfs/file/fn.create_drive.html) from the [standard library](./process_stdlib/overview.md):
 
 ```rust
 let drive_path: String = create_drive(our.package_id(), "drive_name")?;


### PR DESCRIPTION
1. 'The primary way to access files within your node is through the [VFS API](./apis/vfs.md).
The VFS API follows [std::fs](https://doc.rust-lang.org/std/fs/index.html) closely, adding some capabilities checks on paths and some combinatory actions.'

- what do you mean by combinatory actions?

2. This section (2.6. Files) and the next one (2.7. Databases) have 'References' at the bottom. I added some of those links in the text as well (where appropriate). Do you prefer:
- links in text but no references, or
- references but no links in text, or
- both links in text and references?
