### PR TITLE
Section 4. and 4.X. Kit

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,0 @@
-KIT_LOG_PATH=.

--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+KIT_LOG_PATH=.

--- a/src/kit-dev-toolkit.md
+++ b/src/kit-dev-toolkit.md
@@ -1,6 +1,6 @@
 # kit
 
-`kit` is a tool**kit** to make development on Kinode OS ergonomic.
+[`kit`](https://github.com/kinode-dao/kit) is a tool**kit** to make development on Kinode OS ergonomic.
 
 ## Table of Contents
 

--- a/src/kit-dev-toolkit.md
+++ b/src/kit-dev-toolkit.md
@@ -1,6 +1,6 @@
 # kit
 
-[`kit`](https://github.com/kinode-dao/kit) is a tool**kit** to make development on Kinode OS ergonomic.
+[`kit`](https://github.com/kinode-dao/kit) is a CLI tool**kit** to make development on Kinode OS ergonomic.
 
 ## Table of Contents
 

--- a/src/kit/boot-fake-node.md
+++ b/src/kit/boot-fake-node.md
@@ -140,7 +140,8 @@ The password of the fake node; defaults to `secret`.
 
 ### `--release`
 
-If `--runtime-path` is given, build the runtime for release; default is debug. The tradeoffs between the release and default version are described [here](https://doc.rust-lang.org/book/ch01-03-hello-cargo.html?highlight=release#building-for-release).
+If `--runtime-path` is given, build the runtime for release; default is debug.
+The tradeoffs between the release and default version are described [here](https://doc.rust-lang.org/book/ch01-03-hello-cargo.html?highlight=release#building-for-release).
 
 ### `--verbosity`
 

--- a/src/kit/boot-fake-node.md
+++ b/src/kit/boot-fake-node.md
@@ -34,7 +34,7 @@ Fake nodes make development easier.
 A fake node is not connected to the network, but otherwise behaves the same as a live node.
 Fake nodes are connected to each other on your local machine through a network router that passes messages between them.
 Fake nodes also clean up after themselves, so you don't have to worry about state from a previous iterations messing up the current one.
-If you wish to persist a state of a fake node between boots, you can do so with `--persist`.
+If you wish to persist the state of a fake node between boots, you can do so with `--persist`.
 Thus, fake nodes are an excellent testing ground during development for fast iteration.
 
 There are some cases where fake nodes are not appropriate.

--- a/src/kit/boot-fake-node.md
+++ b/src/kit/boot-fake-node.md
@@ -38,8 +38,8 @@ If you wish to persist a state of a fake node between boots, you can do so with 
 Thus, fake nodes are an excellent testing ground during development for fast iteration.
 
 There are some cases where fake nodes are not appropriate.
-The weakness of fake nodes is also their strength: they are not connected to the live network.
-Though this lack of connectivity makes them easy to spin up and throw away, the downside is no access to services on the network, like remote LLMs.
+The weakness of fake nodes is also their strength: they are not connected to the live Kinode network.
+Though this lack of connectivity makes them easy to spin up and throw away, the downside is no access to services on the network which live Kinodes may provide.
 
 ## Arguments
 
@@ -64,8 +64,6 @@ Options:
           The port to run the network router on (or to connect to) [default: 9001]
       --rpc <RPC_ENDPOINT>
           Ethereum RPC endpoint (wss://)
-      --testnet
-          If set, use Sepolia testnet
       --persist
           If set, do not delete node home after exit
       --password <PASSWORD>
@@ -96,7 +94,7 @@ Overrides `--version`.
 
 short: `-v`
 
-Fetch and run a specific version of the binary; defaults to most recent version (here, `0.5.0`).
+Fetch and run a specific version of the binary; defaults to most recent version.
 Overridden by `--runtime-path`.
 
 ### `--port`
@@ -126,17 +124,25 @@ Additional fake nodes must point to the same port to connect to the fake node ne
 
 The Ethereum RPC endpoint to use, if desired.
 
-### `--testnet`
-
-Connect to the Sepolia testnet rather than the Optimism mainnet.
-
 ### `--persist`
 
 Persist the node home directory after exit, rather than cleaning it up.
 
+Example usage:
+
+``` bash
+kit boot-fake-node --persist --home ./my-fake-node
+```
+
+After shutting down the node, to run it again:
+
+```bash
+kit boot-fake-node --home ./my-fake-node
+```
+
 ### `--password`
 
-The password of the fake node; defaults to `secret`.
+The password of the fake node; defaults to "`secret`".
 
 ### `--release`
 
@@ -145,4 +151,4 @@ The tradeoffs between the release and default version are described [here](https
 
 ### `--verbosity`
 
-Set the verbosity of the node; higher is more verbose; default is `0`.
+Set the verbosity of the node; higher is more verbose; default is `0`, max is `3`.

--- a/src/kit/boot-fake-node.md
+++ b/src/kit/boot-fake-node.md
@@ -19,7 +19,7 @@ For example, to start two fake nodes, `fake.os` and `fake2.os`:
 kit boot-fake-node
 
 # In a new terminal
-kit boot-fake-node -h /tmp/kinode-fake-node-2 -p 8081 -f fake2.os
+kit boot-fake-node --home /tmp/kinode-fake-node-2 -p 8081 --fake-node-name fake2.os
 
 # Send a message from fake2.os to fake.os
 # In the terminal of fake2.os:
@@ -34,6 +34,7 @@ Fake nodes make development easier.
 A fake node is not connected to the network, but otherwise behaves the same as a live node.
 Fake nodes are connected to each other on your local machine through a network router that passes messages between them.
 Fake nodes also clean up after themselves, so you don't have to worry about state from a previous iterations messing up the current one.
+If you wish to persist a state of a fake node between boots, you can do so with `--persist`.
 Thus, fake nodes are an excellent testing ground during development for fast iteration.
 
 There are some cases where fake nodes are not appropriate.
@@ -43,7 +44,7 @@ Though this lack of connectivity makes them easy to spin up and throw away, the 
 ## Arguments
 
 ```
-$ kit f --help
+$ kit boot-fake-node --help
 Boot a fake node for development
 
 Usage: kit boot-fake-node [OPTIONS]
@@ -79,7 +80,9 @@ Options:
 
 ### `--runtime-path`
 
-Pass to run a local binary or build a local Kinode core repo and use the resulting binary, e.g.
+short: `-r`
+
+Pass to boot a fake node from a local binary or build a local Kinode core repo and use the resulting binary, e.g.
 
 ```
 kit boot-fake-node --runtime-path ~/git/kinode
@@ -91,18 +94,26 @@ Overrides `--version`.
 
 ### `--version`
 
+short: `-v`
+
 Fetch and run a specific version of the binary; defaults to most recent version (here, `0.5.0`).
 Overridden by `--runtime-path`.
 
 ### `--port`
 
+short: `-p`
+
 Run the fake node on this port; defaults to `8080`.
 
 ### `--home`
 
+short: `-h`
+
 Path to place fake node home directory at; defaults to `/tmp/kinode-fake-node`.
 
 ### `--fake-node-name`
+
+short: `-f`
 
 The name of the fake node; defaults to `fake.os`.
 
@@ -129,7 +140,7 @@ The password of the fake node; defaults to `secret`.
 
 ### `--release`
 
-If `--runtime-path` is given, build the runtime for release; default is debug.
+If `--runtime-path` is given, build the runtime for release; default is debug. The tradeoffs between the release and default version are described [here](https://doc.rust-lang.org/book/ch01-03-hello-cargo.html?highlight=release#building-for-release).
 
 ### `--verbosity`
 

--- a/src/kit/build.md
+++ b/src/kit/build.md
@@ -23,7 +23,25 @@ Currently, `rs`, `py`, and `js` are supported, corresponding to processes writte
 Note that a package may have more than one process and those processes need not be written in the same language.
 
 After compiling each process, it places the output `.wasm` binaries within the `pkg/` directory at the top-level of the given package directory.
-The `pkg/` directory should then be zipped and injected into the node with [`kit start-package`](./start-package.md).
+Here is an example of what a folder structure can look like after using `kit build`:
+
+```
+rustchat
+├── Cargo.lock
+├── Cargo.toml
+├── metadata.json
+├── pkg
+│   ├── manifest.json
+│   ├── rustchat.wasm
+│   ├── scripts.json
+│   └── send.wasm
+├── rustchat
+│   └── ...
+└── send
+    └── ...
+```
+
+The `pkg/` directory can then be zipped and injected into the node with [`kit start-package`](./start-package.md).
 
 `kit build` also builds the UI if it is found in `pkg/ui/`.
 There must exist a `ui/package.json` file with a `scripts` object containing the following arguments:

--- a/src/kit/build.md
+++ b/src/kit/build.md
@@ -68,11 +68,11 @@ Arguments:
   [DIR]  The package directory to build [default: /home/nick/git/kit]
 
 Options:
-      --no-ui            If set, do NOT build the web UI for the process; no-op if passed with UI_ONLY
-      --ui-only          If set, build ONLY the web UI for the process
-  -s, --skip-deps-check  If set, do not check for dependencies
+      --no-ui                If set, do NOT build the web UI for the process; no-op if passed with UI_ONLY
+      --ui-only              If set, build ONLY the web UI for the process
+  -s, --skip-deps-check      If set, do not check for dependencies
       --features <FEATURES>  Pass these comma-delimited feature flags to Rust cargo builds
-  -h, --help             Print help
+  -h, --help                 Print help
 ```
 
 ### Optional positional arg: `DIR`

--- a/src/kit/build.md
+++ b/src/kit/build.md
@@ -91,8 +91,12 @@ Otherwise, for a package with a UI, both the package and the UI will be built.
 
 ### `--quiet`
 
+short: `-q`
+
 Don't print the build stdout/stderr.
 
 ### `--skip-deps-check`
+
+short: `-s`
 
 Don't check for dependencies.

--- a/src/kit/build.md
+++ b/src/kit/build.md
@@ -68,6 +68,7 @@ Arguments:
   [DIR]  The package directory to build [default: /home/nick/git/kit]
 
 Options:
+      --no-ui            If set, do NOT build the web UI for the process; no-op if passed with UI_ONLY
       --ui-only          If set, build ONLY the web UI for the process
   -q, --quiet            If set, do not print build stdout/stderr
   -s, --skip-deps-check  If set, do not check for dependencies
@@ -77,6 +78,11 @@ Options:
 ### Optional positional arg: `DIR`
 
 The package directory to build; defaults to the current working directory.
+
+### `--no-ui`
+
+Do not build the web UI for the process.
+Does nothing if passed with `--ui-only`.
 
 ### `--ui-only`
 

--- a/src/kit/build.md
+++ b/src/kit/build.md
@@ -23,15 +23,16 @@ Currently, `rs`, `py`, and `js` are supported, corresponding to processes writte
 Note that a package may have more than one process and those processes need not be written in the same language.
 
 After compiling each process, it places the output `.wasm` binaries within the `pkg/` directory at the top-level of the given package directory.
-The `pkg/` directory is the one that is zipped and injected into the node by [`kit start-package`](./start-package.md).
-Thus, after `build`ing, the package is ready for `start-package`.
+The `pkg/` directory should then be zipped and injected into the node with [`kit start-package`](./start-package.md).
 
-`kit build` also builds the UI if found in `ui/`.
-There must exist a `ui/package.json` file with `scripts` defined like:
-```
-"build": "tsc && vite build",
-"copy": "mkdir -p ../pkg/ui && rm -rf ../pkg/ui/* && cp -r dist/* ../pkg/ui/",
-"build:copy": "npm run build && npm run copy",
+`kit build` also builds the UI if it is found in `pkg/ui/`.
+There must exist a `ui/package.json` file with a `scripts` object containing the following arguments:
+```json
+"scripts": {
+  "build": "tsc && vite build",
+  "copy": "mkdir -p ../pkg/ui && rm -rf ../pkg/ui/* && cp -r dist/* ../pkg/ui/",
+  "build:copy": "npm run build && npm run copy",
+}
 ```
 
 Additional UI dev info can be found [here](../apis/frontend_development.md).
@@ -40,7 +41,7 @@ To both `build` and `start-package` in one command, use `kit build-start-package
 ## Arguments
 
 ```
-$ kit b --help
+$ kit build --help
 Build a Kinode package
 
 Usage: kit build [OPTIONS] [DIR]

--- a/src/kit/build.md
+++ b/src/kit/build.md
@@ -70,8 +70,8 @@ Arguments:
 Options:
       --no-ui            If set, do NOT build the web UI for the process; no-op if passed with UI_ONLY
       --ui-only          If set, build ONLY the web UI for the process
-  -q, --quiet            If set, do not print build stdout/stderr
   -s, --skip-deps-check  If set, do not check for dependencies
+      --features <FEATURES>  Pass these comma-delimited feature flags to Rust cargo builds
   -h, --help             Print help
 ```
 
@@ -89,14 +89,15 @@ Does nothing if passed with `--ui-only`.
 Build ONLY the UI for a package with a UI.
 Otherwise, for a package with a UI, both the package and the UI will be built.
 
-### `--quiet`
-
-short: `-q`
-
-Don't print the build stdout/stderr.
-
 ### `--skip-deps-check`
 
 short: `-s`
 
 Don't check for dependencies.
+
+### `--features`
+
+Build the package with the given [cargo features](https://doc.rust-lang.org/cargo/reference/features.html).
+
+Features can be used like shown [here](https://doc.rust-lang.org/cargo/reference/features.html#command-line-feature-options).
+Currently the only feature supported system-wide is `simulation-mode`.

--- a/src/kit/build.md
+++ b/src/kit/build.md
@@ -23,7 +23,7 @@ Currently, `rs`, `py`, and `js` are supported, corresponding to processes writte
 Note that a package may have more than one process and those processes need not be written in the same language.
 
 After compiling each process, it places the output `.wasm` binaries within the `pkg/` directory at the top-level of the given package directory.
-Here is an example of what a folder structure can look like after using `kit build`:
+Here is an example of what a package directory will look like after using `kit build`:
 
 ```
 rustchat

--- a/src/kit/build.md
+++ b/src/kit/build.md
@@ -12,7 +12,7 @@ or
 kit build
 ```
 
-`kit build` builds each process in the package and places the `.wasm` binaries into the `pkg/` directory for installation.
+`kit build` builds each process in the package and places the `.wasm` binaries into the `pkg/` directory for installation with [`kit start-package`](./start-package.md).
 It automatically detects what language each process is, and builds it appropriately (from amongst the supported `rust`, `python`, and `javascript`).
 
 ## Discussion

--- a/src/kit/dev-ui.md
+++ b/src/kit/dev-ui.md
@@ -15,7 +15,7 @@ kit dev-ui
 ## Arguments
 
 ```
-$ kit d --help
+$ kit dev-ui --help
 Start the web UI development server with hot reloading (same as `cd ui && npm i && npm start`)
 
 Usage: kit dev-ui [OPTIONS] [DIR]

--- a/src/kit/dev-ui.md
+++ b/src/kit/dev-ui.md
@@ -36,15 +36,21 @@ The UI-enabled package directory to serve; defaults to current working directory
 
 ### `--port`
 
+short: `-p`
+
 For nodes running on localhost, the port of the node; defaults to `8080`.
 `--port` is overridden by `--url` if both are supplied.
 
 ### `--url`
+
+short: `-u`
 
 The URL the node is hosted at.
 Can be either localhost or remote.
 `--url` overrides `--port` if both are supplied.
 
 ### `--skip-deps-check`
+
+short: `-s`
 
 Don't check for dependencies.

--- a/src/kit/inject-message.md
+++ b/src/kit/inject-message.md
@@ -22,7 +22,7 @@ To instead "fire and forget" a message and exit immediately, use the [`--non-blo
 ## Arguments
 
 ```
-$ kit i --help
+$ kit inject-message --help
 Inject a message to a running Kinode
 
 Usage: kit inject-message [OPTIONS] <PROCESS> <BODY_JSON>
@@ -68,7 +68,8 @@ E.g.
 kit inject-message foo:foo:template.os '{"Send": {"target": "fake.os", "message": "wow, it works!"}}' --node fake2.os
 ```
 
-sent to the port running `fake.os` will forward the message from `fake.os`s HTTP server to `fake2@foo:foo:template.os`.
+sent to the port running `fake.os`.
+It will forward the message from `fake.os`s HTTP server to `fake2@foo:foo:template.os`.
 
 ### `--blob`
 

--- a/src/kit/inject-message.md
+++ b/src/kit/inject-message.md
@@ -62,14 +62,12 @@ Can be either localhost or remote.
 ### `--node`
 
 Node to target (i.e. the node portion of the address).
-E.g.
 
-```bash
+E.g., the following, sent to the port running `fake.os`, will be forwarded from `fake.os`'s HTTP server to `fake2@foo:foo:template.os`:
+
+``` bash
 kit inject-message foo:foo:template.os '{"Send": {"target": "fake.os", "message": "wow, it works!"}}' --node fake2.os
 ```
-
-sent to the port running `fake.os`.
-It will forward the message from `fake.os`s HTTP server to `fake2@foo:foo:template.os`.
 
 ### `--blob`
 

--- a/src/kit/inject-message.md
+++ b/src/kit/inject-message.md
@@ -50,16 +50,22 @@ The message body.
 
 ### `--port`
 
+short: `-p`
+
 For nodes running on localhost, the port of the node; defaults to `8080`.
 `--port` is overridden by `--url` if both are supplied.
 
 ### `--url`
+
+short: `-u`
 
 The URL the node is hosted at.
 Can be either localhost or remote.
 `--url` overrides `--port` if both are supplied.
 
 ### `--node`
+
+short: `-n`
 
 Node to target (i.e. the node portion of the address).
 
@@ -71,9 +77,13 @@ kit inject-message foo:foo:template.os '{"Send": {"target": "fake.os", "message"
 
 ### `--blob`
 
+short: `-b`
+
 Path to file to include as `lazy_load_blob`.
 
 ### `--non-block`
+
+short: `-l`
 
 Don't block waiting for a Response from target process.
 Instead, inject the message and immediately return.

--- a/src/kit/install.md
+++ b/src/kit/install.md
@@ -14,7 +14,7 @@ Commands:
   boot-fake-node       Boot a fake node for development [aliases: f]
   build                Build a Kinode package [aliases: b]
   build-start-package  Build and start a Kinode package [aliases: bs]
-  dev-ui               Start the web UI development server with hot reloading (same as `cd ui && npm i && npm run dev` [aliases: d]
+  dev-ui               Start the web UI development server with hot reloading (same as `cd ui && npm i && npm run dev`) [aliases: d]
   inject-message       Inject a message to a running Kinode [aliases: i]
   new                  Create a Kinode template package [aliases: n]
   remove-package       Remove a running package from a node [aliases: r]
@@ -56,8 +56,8 @@ You can find the source for `kit` at [https://github.com/kinode-dao/kit](https:/
 
 ## Logging
 
-Logs are printed to the screen and stored, by default, at `/tmp/kinode-kit-cache/logs/log.log`.
-The default logging level is `info`.
+Logs are printed to the terminal and stored, by default, at `/tmp/kinode-kit-cache/logs/log.log`.
+The default logging level is `info`. Other logging levels are: `debug`, `warning` and `error`.
 
 These defaults can be changed by setting environment variables:
 
@@ -65,3 +65,9 @@ Environment Variable | Description
 -------------------- | -----------
 `KIT_LOG_PATH`       | Set log path (default `/tmp/kinode-kit-cache/logs/log.log`).
 `RUST_LOG`           | Set log level (default `info`).
+
+For example, in Bash:
+
+```bash
+export RUST_LOG=info
+```

--- a/src/kit/install.md
+++ b/src/kit/install.md
@@ -2,7 +2,7 @@
 
 
 These documents describe some ways you can use these tools, but do not attempt to be completely exhaustive.
-You are encouraged to make use of the `--help` flag, which can be used for top-level `kit` commands:
+You are encouraged to make use of the `--help` flag, which can be used for the top-level `kit` command:
 
 ```
 $ kit --help

--- a/src/kit/install.md
+++ b/src/kit/install.md
@@ -2,7 +2,7 @@
 
 
 These documents describe some ways you can use these tools, but do not attempt to be completely exhaustive.
-You are encouraged to make use of the `--help` flag, which can be used for the top-level `kit`:
+You are encouraged to make use of the `--help` flag, which can be used for top-level `kit` commands:
 
 ```
 $ kit --help

--- a/src/kit/install.md
+++ b/src/kit/install.md
@@ -57,7 +57,8 @@ You can find the source for `kit` at [https://github.com/kinode-dao/kit](https:/
 ## Logging
 
 Logs are printed to the terminal and stored, by default, at `/tmp/kinode-kit-cache/logs/log.log`.
-The default logging level is `info`. Other logging levels are: `debug`, `warning` and `error`.
+The default logging level is `info`.
+Other logging levels are: `debug`, `warning` and `error`.
 
 These defaults can be changed by setting environment variables:
 

--- a/src/kit/new.md
+++ b/src/kit/new.md
@@ -28,7 +28,7 @@ Currently, three languages are supported: `rust` (the default), `python`, and `j
 Four templates are currently supported, as described in the [following section](./new.html#existshas-ui-enabled-version).
 In addition, some subset of these templates also have a UI-enabled version.
 
-### Exists/Has UI-enabled version
+### Exists/Has UI-enabled Version
 
 The following table specifies whether a template "Exists/Has UI-enabled version" for each language/template combination:
 
@@ -37,6 +37,13 @@ Language     | `chat`  | `echo` | `fibonacci` | `file_transfer`
 `rust`       | yes/yes | yes/no | yes/no      | yes/no
 `python`     | yes/no  | yes/no | yes/no      | no/no
 `javascript` | yes/no  | yes/no | yes/no      | no/no
+
+Brief description of each template:
+
+- `chat`: A simple chat app.
+- `echo`: Echos back any message it receives.
+- `fibonacci`: Computes the n-th Fibonacci number.
+- `file_transfer`: Allows for file transfers between nodes.
 
 ## Arguments
 

--- a/src/kit/new.md
+++ b/src/kit/new.md
@@ -25,12 +25,12 @@ kit new my_py_fib --language python --template fibonacci
 
 You can create a variety of templates using `kit new`.
 Currently, three languages are supported: `rust` (the default), `python`, and `javascript`.
-Two templates are currently supported: `chat`, a simple chat application; and `fibonacci`, which computes Fibonacci numbers.
+Four templates are currently supported, as described in the [following section](./new.html#existshas-ui-enabled-version).
 In addition, some subset of these templates also have a UI-enabled version.
 
-### Exists/Has UI-enabled vesion
+### Exists/Has UI-enabled version
 
-The following table describes specifies whether a template "Exists/Has UI-enabled version" for each language/template combination:
+The following table specifies whether a template "Exists/Has UI-enabled version" for each language/template combination:
 
 Language     | `chat`  | `echo` | `fibonacci` | `file_transfer`
 ------------ | ------- | ------ | ----------- | ---------------
@@ -60,7 +60,7 @@ Options:
 
 ### Positional arg: `DIR`
 
-Directory where to create the template package.
+Create the template package in this directory.
 By default the package name is set to the name specified here, if not supplied by `--package`.
 
 ### `--package`
@@ -81,7 +81,7 @@ Currently supports `rust`, `python`, and `javascript`.
 ### `--template`
 
 Which template to create; defaults to `chat`.
-Currently have `chat`, a simple chat application; `echo`, an application that prints and responds with the received message; and `fibonacci`, a naive fibonacci-number-computer.
+Options are outlined in [Exists/Has UI-enabled version](./new.html#existshas-ui-enabled-version).
 
 ### `--ui`
 

--- a/src/kit/new.md
+++ b/src/kit/new.md
@@ -65,20 +65,28 @@ By default the package name is set to the name specified here, if not supplied b
 
 ### `--package`
 
+short: `-a`
+
 Name of the package; defaults to `DIR`.
 Must be URL-safe.
 
 ### `--publisher`
+
+short: `-u`
 
 Name of the publisher; defaults to `template.os`.
 Must be URL-safe.
 
 ### `--language`
 
+short: `-l`
+
 Template language; defaults to `rust`.
 Currently supports `rust`, `python`, and `javascript`.
 
 ### `--template`
+
+short: `-t`
 
 Which template to create; defaults to `chat`.
 Options are outlined in [Exists/Has UI-enabled version](./new.html#existshas-ui-enabled-version).

--- a/src/kit/new.md
+++ b/src/kit/new.md
@@ -18,19 +18,19 @@ kit new my_rust_chat
 kit new my_rust_chat_with_ui --ui
 
 # Create fibonacci in python
-kit new my_py_fib -l python -t fibonacci
+kit new my_py_fib --language python --template fibonacci
 ```
 
 ## Discussion
 
 You can create a variety of templates using `kit new`.
 Currently, three languages are supported: `rust` (the default), `python`, and `javascript`.
-Two templates are currently supported: `chat`, a simple chat application, and `fibonacci`, which computes Fibonacci numbers.
+Two templates are currently supported: `chat`, a simple chat application; and `fibonacci`, which computes Fibonacci numbers.
 In addition, some subset of these templates also have a UI-enabled version.
 
-The following table describes the matrix of ["Exists/Has UI-enabled version"](#existshas-ui-enabled-vesion) for each template/language combination:
-
 ### Exists/Has UI-enabled vesion
+
+The following table describes specifies whether a template "Exists/Has UI-enabled version" for each language/template combination:
 
 Language     | `chat`  | `echo` | `fibonacci` | `file_transfer`
 ------------ | ------- | ------ | ----------- | ---------------
@@ -41,7 +41,7 @@ Language     | `chat`  | `echo` | `fibonacci` | `file_transfer`
 ## Arguments
 
 ```
-$ kit n --help
+$ kit new --help
 Create a Kinode template package
 
 Usage: kit new [OPTIONS] <DIR>
@@ -60,8 +60,8 @@ Options:
 
 ### Positional arg: `DIR`
 
-Where to create the template package.
-The package name is set to this by default if not supplied by `--package`.
+Directory where to create the template package.
+By default the package name is set to the name specified here, if not supplied by `--package`.
 
 ### `--package`
 
@@ -76,12 +76,12 @@ Must be URL-safe.
 ### `--language`
 
 Template language; defaults to `rust`.
-Currently support `rust`, `python`, and `javascript`.
+Currently supports `rust`, `python`, and `javascript`.
 
 ### `--template`
 
 Which template to create; defaults to `chat`.
-Currently have `chat`, a simple chat application, `echo`, an application that prints and responds with the received message, and `fibonacci`, a naive fibonacci-number-computer.
+Currently have `chat`, a simple chat application; `echo`, an application that prints and responds with the received message; and `fibonacci`, a naive fibonacci-number-computer.
 
 ### `--ui`
 

--- a/src/kit/remove-package.md
+++ b/src/kit/remove-package.md
@@ -15,7 +15,7 @@ kit remove-package -package foo --publisher template.os
 
 ## Discussion
 
-If passed an optional positional argument `DIR` (the path to a package directory), the `metadata.json` therein is parsed and that package is removed from the node.
+If passed an optional positional argument `DIR` (the path to a package directory), the `metadata.json` therein is parsed to get the `packageID` and that package is removed from the node.
 If no arguments are provided, the same process happens for the current working directory.
 Alternatively, a `--package` and `--publisher` can be provided as arguments, and that package will be removed.
 

--- a/src/kit/remove-package.md
+++ b/src/kit/remove-package.md
@@ -1,6 +1,6 @@
 # `kit remove-package`
 
-`kit remove-package` removes an installed package from a given node (defaults to `localhost:8080`).
+`kit remove-package` removes an installed package from the given node (defaults to `localhost:8080`).
 
 For example,
 ```

--- a/src/kit/remove-package.md
+++ b/src/kit/remove-package.md
@@ -44,6 +44,8 @@ The package directory to be removed from the node; defaults to current working d
 
 ### `--package`
 
+short: `-a`
+
 The package name of the package to be removed; default is derived from `metadata.json` in `DIR`.
 
 ### `--publisher`
@@ -52,10 +54,14 @@ The publisher of the package to be removed; default is derived from `metadata.js
 
 ### `--port`
 
+short: `-p`
+
 For nodes running on localhost, the port of the node; defaults to `8080`.
 `--port` is overridden by `--url` if both are supplied.
 
 ### `--url`
+
+short: `-u`
 
 The URL the node is hosted at.
 Can be either localhost or remote.

--- a/src/kit/remove-package.md
+++ b/src/kit/remove-package.md
@@ -15,7 +15,7 @@ kit remove-package -package foo --publisher template.os
 
 ## Discussion
 
-If passed an optional positional argument `DIR` (the path to a package directory), the `metadata.json` therein is parsed to get the `packageID` and that package is removed from the node.
+If passed an optional positional argument `DIR` (the path to a package directory), the `metadata.json` therein is parsed to get the `package_id` and that package is removed from the node.
 If no arguments are provided, the same process happens for the current working directory.
 Alternatively, a `--package` and `--publisher` can be provided as arguments, and that package will be removed.
 

--- a/src/kit/remove-package.md
+++ b/src/kit/remove-package.md
@@ -1,9 +1,6 @@
 # `kit remove-package`
 
-`kit remove-package` removes an installed package from the given node.
-If passed an optional positional argument `DIR`, the path to a package directory, the `metadata.json` therein is parsed and that package is removed from the node.
-If no arguments are provided, the same process happens for the current working directory.
-Alternatively, a `--package` and `--publisher` can be provided as arguments, and that package will be removed.
+`kit remove-package` removes an installed package from a given node (defaults to `localhost:8080`).
 
 For example,
 ```
@@ -18,15 +15,14 @@ kit remove-package -package foo --publisher template.os
 
 ## Discussion
 
-`kit start-package` injects a built package into the given node and starts it.
-`start-package` is designed to be used after a package has been built with [`kit build`](./build.md).
-Specifically, it first zips and injects the `pkg/` directory within the given package directory, which contains metadata about the package for the node as well as the `.wasm` binaries for each process.
-Then it injects a message to the node to start the package.
+If passed an optional positional argument `DIR` (the path to a package directory), the `metadata.json` therein is parsed and that package is removed from the node.
+If no arguments are provided, the same process happens for the current working directory.
+Alternatively, a `--package` and `--publisher` can be provided as arguments, and that package will be removed.
 
 ## Arguments
 
 ```
-$ kit r --help
+$ kit remove-package --help
 Remove a running package from a node
 
 Usage: kit remove-package [OPTIONS] [DIR]
@@ -44,15 +40,15 @@ Options:
 
 ### Optional positional arg: `DIR`
 
-The package directory to install and start on the node; defaults to current working directory.
+The package directory to be removed from the node; defaults to current working directory.
 
 ### `--package`
 
-The package name of the package to be removed; default is derived from `DIR`.
+The package name of the package to be removed; default is derived from `metadata.json` in `DIR`.
 
 ### `--publisher`
 
-The publisher of the package to be removed; default is derived from `DIR`.
+The publisher of the package to be removed; default is derived from `metadata.json` in `DIR`.
 
 ### `--port`
 

--- a/src/kit/reset-cache.md
+++ b/src/kit/reset-cache.md
@@ -1,6 +1,6 @@
 # `kit reset-cache`
 
-`kit reset-cache` resets the cache `kit` writes Kinode core binaries, logs, etc. to.
+The `kit reset-cache` command clears the cache where `kit` stores Kinode core binaries, logs, etc.
 
 ## Discussion
 

--- a/src/kit/run-tests.md
+++ b/src/kit/run-tests.md
@@ -21,7 +21,7 @@ Each test is run in a fresh environment of one or more fake nodes.
 A test can setup one or more packages before running a series of test packages.
 Each test package is [a single-process package that accepts and responds with certain messages](#test-package-format).
 
-Tests are orchestrated from the outside of the node by `kit run-tests` and run on the inside of the node by the `tester` core package.
+Tests are orchestrated from the outside of the node by `kit run-tests` and run on the inside of the node by the [`tester`](https://github.com/kinode-dao/kinode/tree/main/kinode/packages/tester) core package.
 For a given test, the `tester` package runs the specified test packages in order.
 Each test package must respond to the `tester` package with a `Pass` or `Fail`.
 The `tester` package stops on the first `Fail`, or responds with a `Pass` if all tests `Pass`.
@@ -30,7 +30,7 @@ If a given test `Pass`es, the next test in the series is run.
 ## Arguments
 
 ```
-$ kit t --help
+$ kit run-tests --help
 Run Kinode tests
 
 Usage: kit run-tests [PATH]
@@ -49,111 +49,21 @@ Path to [`.toml`](https://toml.io/en/) file specifying tests to run; defaults to
 ## `tests.toml`
 
 The testing protocol is specified by a `.toml` file.
-Consider the following example, from [core tests]():
+We will be referring to `tests.toml` as an example, from [core tests]().
 
-```toml
-runtime = { FetchVersion = "latest" }
-runtime_build_release = true
-
-
-[[tests]]
-setup_package_paths = ["chat"]
-test_packages = [
-    { path = "chat_test", "grant_capabilities" = ["chat:chat:template.os"] },
-    { path = "key_value_test", grant_capabilities = ["kv:distro:sys"] },
-    { path = "sqlite_test", grant_capabilities = ["sqlite:distro:sys"] },
-]
-timeout_secs = 5
-# Plan to include defects = Latency, Dropping, ..., All
-network_router = { port = 9001, defects = "None" }
-
-[[tests.nodes]]
-port = 8080
-home = "home/first"
-fake_node_name = "first.os"
-is_testnet = true
-runtime_verbosity = 0
-
-[[tests.nodes]]
-port = 8081
-home = "home/second"
-fake_node_name = "second.os"
-is_testnet = true
-runtime_verbosity = 0
-
-
-[[tests]]
-setup_package_paths = []
-test_packages = [
-    { path = "key_value_test", grant_capabilities = ["kv:distro:sys"] }
-]
-mute_package_build = true
-timeout_secs = 5
-network_router = { port = 9001, defects = "None" }
-
-[[tests.nodes]]
-port = 8080
-home = "home/first"
-fake_node_name = "first.os"
-is_testnet = true
-runtime_verbosity = 0
-```
-
-which has the directory structure
-
-```bash
-core_tests
-├── chat
-│   ├── metadata.json
-│   ├── chat
-│   │   ├── Cargo.toml
-│   │   └── src
-│   │       └── lib.rs
-│   └── pkg
-│       └── manifest.json
-├── chat_test
-│   ├── metadata.json
-│   ├── chat_test
-│   │   ├── Cargo.toml
-│   │   └── src
-│   │       ├── lib.rs
-│   │       └── tester_types.rs
-│   └── pkg
-│       └── manifest.json
-├── key_value_test
-│   ├── metadata.json
-│   ├── key_value_test
-│   │   ├── Cargo.toml
-│   │   └── src
-│   │       ├── lib.rs
-│   │       └── tester_types.rs
-│   └── pkg
-│       └── manifest.json
-├── sqlite_test
-│   ├── metadata.json
-│   ├── pkg
-│   │   └── manifest.json
-│   └── sqlite_test
-│       ├── Cargo.toml
-│       └── src
-│           ├── lib.rs
-│           └── tester_types.rs
-└── tests.toml
-```
-
-The top-level consists of three fields:
+The top-level of `tests.toml` consists of three fields:
 
 Key                                               | Value Type
 ------------------------------------------------- | ----------
 [`runtime`](#runtime)                             | `{ FetchVersion = "<version>" }` or `{ RepoPath = "~/path/to/repo" }`
 [`runtime_build_release`](#runtime_build_release) | Boolean
-[`tests`](#tests)                                 | Array of Tables
+[`tests`](#tests)                                 | [Array of Tables](https://toml.io/en/v1.0.0#array-of-tables)
 
 ### `runtime`
 
 Specify the runtime to use for the tests.
 Two option variants are supported.
-An option variant is specified with the key of an Table.
+An option variant is specified with the key (e.g. `FetchVersion`) of a `toml` [Table](https://toml.io/en/v1.0.0#table) (e.g. `{FetchVersion = "0.7.2"}`).
 
 The first, and recommended is `FetchVersion`.
 The value of the `FetchVersion` Table is the version number to fetch and use (or `"latest"`).
@@ -163,9 +73,23 @@ The second is `RepoPath`.
 The value of the `RepoPath` Table is the path to a local copy of the runtime repo.
 Given a valid path, that repo will be compiled and used.
 
+For example:
+
+```toml
+runtime = { FetchVersion = "latest" }
+```
+
+
 ### `runtime_build_release`
 
-If given `runtime = RepoPath`, whether to build the runtime as `--release` or not.
+If given `runtime = RepoPath`, `runtime_build_release` decides whether to build the runtime as `--release` or not.
+
+For example:
+
+```toml
+runtime_build_release = true
+```
+
 
 ### `tests`
 
@@ -176,12 +100,33 @@ That test consists of:
 Key                     | Value Type      | Value Description
 ----------------------- | --------------- | -----------------
 `setup_package_paths`   | Array of Paths  | Paths to packages to load into all nodes before running test
-`test_packages`         | Array of Tables | Table containing `path` (to test package) and `grant_capabilities` (which will be granted by test package)
+`test_packages`         | Array of Tables | Each Table in the Array contains `path` (to test package) and `grant_capabilities` (which will be granted by test package)
 `timeout_secs`          | Integer > 0     | Timeout for this entire series of test packages
 `network_router`        | Table           | Table containing `port` (of network router server) and `defects` (to simulate network weather/defects; currently only `"None"` accepted)
 [`nodes`](#nodes)       | Array of Tables | Each Table specifies configuration of one node to spin up for test
 
 Each test package is [a single-process package that accepts and responds with certain messages](#test-package-format).
+
+For example:
+```toml
+[[tests]]
+setup_package_paths = ["chat"]
+test_packages = [
+    { path = "chat_test", grant_capabilities = ["chat:chat:template.os"] },
+    { path = "key_value_test", grant_capabilities = ["kv:distro:sys"] },
+    { path = "sqlite_test", grant_capabilities = ["sqlite:distro:sys"] },
+]
+timeout_secs = 5
+# Plan to include defects = Latency, Dropping, ..., All
+network_router = { port = 9001, defects = "None" }
+
+[[tests.nodes]]
+...
+
+[[tests.nodes]]
+...
+```
+
 
 #### `nodes`
 
@@ -197,10 +142,29 @@ Key                 | Value Type     | Value Description
 `fake_node_name`    | String         | Name of fake node
 `password`          | String or Null | Password of fake node (default: `"secret"`)
 `rpc`               | String or Null | [`wss://` URI of Ethereum RPC](../login.md#starting-the-kinode-node)
-`is_testnet`        | Boolean        | Whether to connect to Sepolia testnet (`false` -> Optimism mainnet)
+`is_testnet`        | Boolean        | Whether to connect to Optimism on Sepolia (`false` -> Optimism mainnet)
 `runtime_verbosity` | Integer >= 0   | The verbosity level to start the runtime with; higher is more verbose (default: `0`)
 
-## Test package format
+For example:
+
+```toml
+[[tests.nodes]]
+port = 8080
+home = "home/first"
+fake_node_name = "first.os"
+is_testnet = true
+runtime_verbosity = 0
+
+[[tests.nodes]]
+port = 8081
+home = "home/second"
+fake_node_name = "second.os"
+is_testnet = true
+runtime_verbosity = 0
+```
+
+
+## Test Package Interface
 
 A test package is a single-process package that accepts and responds with certain messages.
 Those certain messages are:

--- a/src/kit/run-tests.md
+++ b/src/kit/run-tests.md
@@ -49,7 +49,7 @@ Path to [`.toml`](https://toml.io/en/) file specifying tests to run; defaults to
 ## `tests.toml`
 
 The testing protocol is specified by a `.toml` file.
-We will be referring to `tests.toml` as an example, from [core tests]().
+We will be referring to [`tests.toml`](https://github.com/kinode-dao/core_tests/blob/master/tests.toml) as an example, from [core tests](https://github.com/kinode-dao/core_tests).
 
 The top-level of `tests.toml` consists of three fields:
 

--- a/src/kit/run-tests.md
+++ b/src/kit/run-tests.md
@@ -203,6 +203,5 @@ which should be sent as a Response after the test has completed successfully, an
 
 which should be sent as a Response if the test fails.
 
-In the Rust language, there is a helper macro for failutres in `tester_types.rs`.
-That file can be found in the core `modules/tester/tester_types.rs`.
-The macro is `fail!()`: it automatically sends the Response, filing out the fields, and exits.
+In the Rust language, a helper macro for failures can be found in [`tester_types.rs`](https://github.com/kinode-dao/kinode/blob/main/kinode/packages/tester/tester_types.rs).
+The macro is `fail!()`: it automatically sends the Response as specified above, filing out the fields, and exits.

--- a/src/kit/run-tests.md
+++ b/src/kit/run-tests.md
@@ -49,7 +49,7 @@ Path to [`.toml`](https://toml.io/en/) file specifying tests to run; defaults to
 ## `tests.toml`
 
 The testing protocol is specified by a `.toml` file.
-We will be referring to [`tests.toml`](https://github.com/kinode-dao/core_tests/blob/master/tests.toml) as an example, from [core tests](https://github.com/kinode-dao/core_tests).
+[`tests.toml`](https://github.com/kinode-dao/core_tests/blob/master/tests.toml), from [core tests](https://github.com/kinode-dao/core_tests), will be used as an example.
 
 The top-level of `tests.toml` consists of three fields:
 
@@ -142,7 +142,6 @@ Key                 | Value Type     | Value Description
 `fake_node_name`    | String         | Name of fake node
 `password`          | String or Null | Password of fake node (default: `"secret"`)
 `rpc`               | String or Null | [`wss://` URI of Ethereum RPC](../login.md#starting-the-kinode-node)
-`is_testnet`        | Boolean        | Whether to connect to Optimism on Sepolia (`false` -> Optimism mainnet)
 `runtime_verbosity` | Integer >= 0   | The verbosity level to start the runtime with; higher is more verbose (default: `0`)
 
 For example:
@@ -152,14 +151,12 @@ For example:
 port = 8080
 home = "home/first"
 fake_node_name = "first.os"
-is_testnet = true
 runtime_verbosity = 0
 
 [[tests.nodes]]
 port = 8081
 home = "home/second"
 fake_node_name = "second.os"
-is_testnet = true
 runtime_verbosity = 0
 ```
 

--- a/src/kit/start-package.md
+++ b/src/kit/start-package.md
@@ -1,6 +1,6 @@
 # `kit start-package`
 
-`kit start-package` installs and starts the indicated package directory (or current working directory) on a given Kinode (at `localhost:8080` by default), e.g.,
+`kit start-package` installs and starts the indicated package directory (or current working directory) on the given Kinode (at `localhost:8080` by default), e.g.,
 
 ```
 kit start-package foo

--- a/src/kit/start-package.md
+++ b/src/kit/start-package.md
@@ -1,6 +1,6 @@
 # `kit start-package`
 
-`kit start-package` installs and starts the indicated package directory (or current working directory) on a given Kinode (at localhost:8080 by default), e.g.,
+`kit start-package` installs and starts the indicated package directory (or current working directory) on a given Kinode (at `localhost:8080` by default), e.g.,
 
 ```
 kit start-package foo

--- a/src/kit/start-package.md
+++ b/src/kit/start-package.md
@@ -44,10 +44,14 @@ The package directory to install and start on the node; defaults to current work
 
 ### `--port`
 
+short: `-p`
+
 For nodes running on localhost, the port of the node; defaults to `8080`.
 `--port` is overridden by `--url` if both are supplied.
 
 ### `--url`
+
+short: `-u`
 
 The URL the node is hosted at.
 Can be either localhost or remote.

--- a/src/kit/start-package.md
+++ b/src/kit/start-package.md
@@ -1,6 +1,6 @@
 # `kit start-package`
 
-`kit start-package` installs and starts the indicated package directory (or current working directory) on the given Kinode, e.g.,
+`kit start-package` installs and starts the indicated package directory (or current working directory) on a given Kinode (at localhost:8080 by default), e.g.,
 
 ```
 kit start-package foo
@@ -16,15 +16,15 @@ kit start-package
 
 `kit start-package` injects a built package into the given node and starts it.
 `start-package` is designed to be used after a package has been built with [`kit build`](./build.md).
-Specifically, it first zips and injects the `pkg/` directory within the given package directory, which contains metadata about the package for the node as well as the `.wasm` binaries for each process.
-Then it injects a message to the node to start the package.
+The `pkg/` directory contains metadata about the package for the node as well as the `.wasm` binaries for each process.
+So `kit start-package` first zips the `pkg/` directory (located in the package directory given in the argument), and then it injects a message to the node to start the package.
 
 To both `build` and `start-package` in one command, use `kit build-start-package`.
 
 ## Arguments
 
 ```
-$ kit s --help
+$ kit start-package --help
 Start a built Kinode process
 
 Usage: kit start-package [OPTIONS] [DIR]


### PR DESCRIPTION
Section 4.1. Installation; Logging
1. 'Logs are printed to the screen and stored, by default, at /tmp/kinode-kit-cache/logs/log.log.'
- what does it mean that logs are printed to the screen?
2. 'The default logging level is `info`.'
- are the other logging levels explained somewhere?
3. 'These defaults can be changed by setting environment variables'
- might be good to have an example of an .env file