### PR TITLE
.os to .dev

### DIFF
--- a/src/apis/http_authentication.md
+++ b/src/apis/http_authentication.md
@@ -7,7 +7,7 @@ This process handles binding (registering) routes, simple JWT-based authenticati
 
 Any process that you build can bind (register) any number of HTTP paths with `http_server`.
 Every path that you bind will be automatically prepended with the current process' ID.
-For example, bind the route `/messages` within a process called `main:my_package:myname.os` like so:
+For example, bind the route `/messages` within a process called `main:my_package:myname.dev` like so:
 
 ```rs
 use kinode_process_lib::{http::bind_http_path};
@@ -15,7 +15,7 @@ use kinode_process_lib::{http::bind_http_path};
 bind_http_path("/messages", true, false).unwrap();
 ```
 
-Now, any HTTP requests to your node at `/main:my_package:myname.os/messages` will be routed to your process.
+Now, any HTTP requests to your node at `/main:my_package:myname.dev/messages` will be routed to your process.
 
 The other two parameters to `bind_http_path` are `authenticated: bool` and `local_only: bool`.
 `authenticated` means that `http_server` will check for an auth cookie (set at login/registration), and `local_only` means that `http_server` will only allow requests that come from `localhost`.
@@ -41,6 +41,7 @@ Note that `url` is the host and full path of the original HTTP request that came
 ## Handling HTTP Requests
 
 Usually, you will want to:
+
 1) determine if an incoming request is a HTTP request.
 2) figure out what kind of `IncomingHttpRequest` it is.
 3) handle the request based on the path and method.

--- a/src/apis/terminal.md
+++ b/src/apis/terminal.md
@@ -1,4 +1,5 @@
 # Terminal API
+
 It is extremely rare for an app to have direct access to the terminal api.
 Normally, the terminal will be used to call scripts, which will have access to the process in question.
 For documentation on using, writing, publishing, and composing scripts, see the [terminal use documentation](../terminal.md), or for a quick start, the [script cookbook](../cookbook/writing_scripts.md).
@@ -16,15 +17,16 @@ For this reason, users are unlikely to grant direct terminal access to most apps
 If one does have the capability to send `Request`s to the terminal, they can execute commands like so:
 `script_name:package_name:publisher_name <ARGS>`
 
-For example, the `hi` script, which pings another node's terminal with a message, can be called like so: `hi:terminal:sys default-router-1.os what's up?`.
-In this case, the arguments are both `default-router-1.os` and the message `what's up?`.
+For example, the `hi` script, which pings another node's terminal with a message, can be called like so: `hi:terminal:sys default-router-1.dev what's up?`.
+In this case, the arguments are both `default-router-1.dev` and the message `what's up?`.
 
 Some commonly used scripts have shorthand aliases because they are invoked so frequently.
-For example, `hi:terminal:sys` can be shortened to just `hi` as in: `hi default-router-1.os what's up?`.
+For example, `hi:terminal:sys` can be shortened to just `hi` as in: `hi default-router-1.dev what's up?`.
 
 The other most commonly used script is `m:terminal:sys`, or just `m` - which stands for `Message`. `m` let's you send a request to any node or application like so:
+
 ```bash
-m john.os@proc:pkg:pub '{"foo":"bar"}'
+m john.dev@proc:pkg:pub '{"foo":"bar"}'
 ```
 
 Note that if your process has the ability to message the `terminal` app, then that process can call any script - of which there may be many on a machine, so we cannot possibly write all of them down in this document.

--- a/src/chess_app/chess_engine.md
+++ b/src/chess_app/chess_engine.md
@@ -1,6 +1,7 @@
 # Chess Engine
 
 Chess is a good example for a Kinode application walk-through because:
+
 1. The basic game logic is already readily available.
    There are thousands of high-quality chess libraries across many languages that can be imported into a Wasm app that runs on Kinode.
    We'll be using [pleco](https://github.com/pleco-rs/Pleco)
@@ -44,6 +45,7 @@ We want to play chess with other people.
 Let's start by creating a persisted state for the chess app and a `body` format for sending messages to other nodes.
 
 In `my_chess/src/lib.rs` add the following simple Request/Response interface and persistable game state:
+
 ```rust
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
@@ -110,11 +112,13 @@ To keep things clean, leverage the request/response pattern and the `context` fi
 
 Below, you'll find the full code for the CLI version of the app.
 You can build it and install it on a node using `kit`.
-You can interact with it in the terminal, primitively, like so (assuming your first node is `fake.os` and second is `fake2.os`):
+You can interact with it in the terminal, primitively, like so (assuming your first node is `fake.dev` and second is `fake2.dev`):
+
 ```
-m our@my_chess:my_chess:template.os '{"NewGame": {"white": "fake.os", "black": "fake2.os"}}'
-m our@my_chess:my_chess:template.os '{"Move": {"game_id": "fake2.os", "move_str": "e2e4"}}'
+m our@my_chess:my_chess:template.dev '{"NewGame": {"white": "fake.dev", "black": "fake2.dev"}}'
+m our@my_chess:my_chess:template.dev '{"Move": {"game_id": "fake2.dev", "move_str": "e2e4"}}'
 ```
+
 (If you want to make a more ergonomic CLI app, consider parsing `body` as a string...)
 
 As you read through the code, you might notice a problem with this app: there's no way to see your games!
@@ -122,6 +126,7 @@ A fun project would be to add a CLI command that shows you, in-terminal, the boa
 But in the [next chapter](./frontend.md), we'll add a frontend to this app so you can see your games in a browser.
 
 `my_chess/Cargo.toml`:
+
 ```toml
 [package]
 name = "my_chess"
@@ -152,6 +157,7 @@ package = "kinode:process"
 ```
 
 `my_chess/src/lib.rs`:
+
 ```rust
 #![feature(let_chains)]
 use pleco::Board;

--- a/src/cookbook/file_transfer.md
+++ b/src/cookbook/file_transfer.md
@@ -254,7 +254,7 @@ Now try this out by [booting two nodes](../kit/boot-fake-node.md#example-usage),
 kit f
 
 # In another terminal
-kit f --home /tmp/kinode-fake-node-2 -p 8081 -f fake2.os
+kit f --home /tmp/kinode-fake-node-2 -p 8081 -f fake2.dev
 ```
 
 and [starting the package](../kit/start-package.md) on both nodes,
@@ -268,13 +268,13 @@ kit s -p 8081
 and then placing files in the `/vfs/file_transfer:file_transfer/files/` directory of the second (the `--home` dir path is specified as an argument to `boot-fake-node`), and sending a request from the first:
 
 ```
-m fake2.os@file_transfer:file_transfer:template.os "ListFiles"
+m fake2.dev@file_transfer:file_transfer:template.os "ListFiles"
 ```
 
 You should see a printed response.
 
 ```md
-Thu 1/11 13:14 response from fake2.os@file_transfer:file_transfer:template.os: {"ListFiles":[{"name":"file_transfer:template.os/files/barry-lyndon.mp4","size":8760244}, {"name":"file_transfer:template.os/files/blue-danube.mp3","size":9668359}]}
+Thu 1/11 13:14 response from fake2.dev@file_transfer:file_transfer:template.os: {"ListFiles":[{"name":"file_transfer:template.dev/files/barry-lyndon.mp4","size":8760244}, {"name":"file_transfer:template.dev/files/blue-danube.mp3","size":9668359}]}
 ```
 
 ### Transfer
@@ -1164,7 +1164,7 @@ There you have it!
 Try and run it, you can download a file with the command
 
 ```
-m our@file_transfer:file_transfer:template.os '{"Download": {"name": "dawg.jpeg", "target": "fake2.os@file_transfer:file_transfer:template.os"}}'
+m our@file_transfer:file_transfer:template.dev '{"Download": {"name": "dawg.jpeg", "target": "fake2.dev@file_transfer:file_transfer:template.os"}}'
 ```
 
 replacing node name and file name!

--- a/src/cookbook/zk_with_sp1.md
+++ b/src/cookbook/zk_with_sp1.md
@@ -7,12 +7,14 @@ There are a number of other ZK proving systems both in production and under deve
 ### Start
 
 In a terminal window, start a fake node to use for development of this app.
+
 ```bash
 kit boot-fake-node
 ```
 
 In another terminal, create a new app using [kit](../kit-dev-toolkit.md).
 Use the fibonacci template, which can then be modified to calculate fibonacci numbers in a *provably correct* way.
+
 ```bash
 kit new my_zk_app -t fibonacci
 cd my_zk_app
@@ -22,12 +24,15 @@ kit bs
 Take note of the basic fibonacci program in the template.
 The program presents a request/response pattern where a requester asks for the nth fibonacci number, and the process calculates and returns it.
 This can be seen in action by running the following command in the fake node's terminal:
+
 ```bash
 m our@my_zk_app:my_zk_app:template.os -a 5 '{"Number": 10}'
 ```
+
 (Change the package name to whatever you named your app + the publisher node as assigned in `metadata.json`.)
 
 You should see a print from the process that looks like this, and a returned JSON response that the terminal prints:
+
 ```
 my_zk_app: fibonacci(10) = 55; 375ns
 {"Number":55}
@@ -38,15 +43,17 @@ my_zk_app: fibonacci(10) = 55; 375ns
 From the template, you have a program that can be used across the Kinode network to perform a certain computation.
 If the template app here has the correct capabilities, other nodes will be able to message it and receive a response.
 This can be seen in action by booting another fake node (while keeping the first one open) and sending the fibonacci program a message:
+
 ```
 # need to set a custom name and port so as not to overlap with first node
-kit boot-fake-node -p 8081 --fake-node-name fake2.os
+kit boot-fake-node -p 8081 --fake-node-name fake2.dev
 # wait for the node to boot
-m fake.os@my_zk_app:my_zk_app:template.os -a 5 '{"Number": 10}'
+m fake.dev@my_zk_app:my_zk_app:template.dev -a 5 '{"Number": 10}'
 ```
-(Replace the target node ID with the first fake node, which by default is `fake.os`)
 
-You should see `{"Number":55}` in the terminal of `fake2.os`!
+(Replace the target node ID with the first fake node, which by default is `fake.dev`)
+
+You should see `{"Number":55}` in the terminal of `fake2.dev`!
 This reveals a fascinating possibility: with Kinode, one can build p2p services accessible to any node on the network.
 However, the current implementation of the fibonacci program is not provably correct.
 The node running the program could make up a number -- without doing the work locally, there's no way to verify the result.
@@ -57,6 +64,7 @@ ZK proofs can solve this problem.
 To add ZK proofs to this simple fibonacci program, you can use the [SP1](https://github.com/succinctlabs/sp1) library to write a program in Rust, then produce proofs against it.
 
 First, add the SP1 dependency to the `Cargo.toml` file for `my_zk_app`:
+
 ```toml
 [dependencies]
 ...
@@ -66,13 +74,16 @@ sp1-core = { git = "https://github.com/succinctlabs/sp1.git" }
 
 Now follow the [SP1 install steps](https://succinctlabs.github.io/sp1/getting-started/install.html) to get the tooling for constructing a provable program.
 After installing you should be able to run
+
 ```
 cargo prove new fibonacci
 ```
+
 and navigate to a project, which conveniently contains a fibonacci function example.
 Modify it slightly to match what our fibonacci program does.
 You can more or less copy-and-paste the fibonacci function from your Kinode app to the `program/src/main.rs` file in the SP1 project.
 It'll look like this:
+
 ```rust
 #![no_main]
 sp1_zkvm::entrypoint!(main);
@@ -97,12 +108,14 @@ pub fn main() {
 
 Now, use SP1's `prove` tool to build the ELF that will actually be executed when the process get a fibonacci request.
 Run this inside the `program` dir of the SP1 project you created:
+
 ```bash
 cargo prove build
 ```
 
 Next, take the generated ELF file from `program/elf/riscv32im-succinct-zkvm-elf` and copy it into the `pkg` dir of your *Kinode* app.
 Go back to your Kinode app code and include this file as bytes so the process can execute it in the SP1 zkVM:
+
 ```rust
 const FIB_ELF: &[u8] = include_bytes!("../../pkg/riscv32im-succinct-zkvm-elf");
 ```
@@ -223,9 +236,11 @@ fn init(our: Address) {
 
 Install this app on two nodes -- they can be the fake `kit` nodes from before, or real ones on the network.
 Next, send a message from one to the other, asking it to generate a fibonacci proof!
+
 ```
-m our@my_zk_app:my_zk_app:template.os -a 30 '{"ProveIt": {"target": "fake.os", "n": 10}}'
+m our@my_zk_app:my_zk_app:template.os -a 30 '{"ProveIt": {"target": "fake.dev", "n": 10}}'
 ```
+
 As usual, set the process ID to what you used, and set the `target` JSON value to the other node's name.
 Try a few different numbers -- see if you can generate a timeout (it's set at 30 seconds now, both in the terminal command and inside the app code).
 If so, the power of this proof system is demonstrated: a user with little compute can ask a peer to do some work for them and quickly verify it!

--- a/src/kit/boot-fake-node.md
+++ b/src/kit/boot-fake-node.md
@@ -22,7 +22,7 @@ For example, to start two fake nodes, `fake.dev` and `fake2.dev`:
 kit boot-fake-node
 
 # In a new terminal
-kit boot-fake-node -f fake2.dev -p 8081 -h /tmp/kinode-fake-node-2
+kit boot-fake-node --home /tmp/kinode-fake-node-2 -p 8081 --fake-node-name fake2.dev
 
 # Send a message from fake2.dev to fake.dev
 # In the terminal of fake2.dev:
@@ -62,7 +62,7 @@ Options:
   -h, --home <HOME>
           Where to place the home directory for the fake node [default: /tmp/kinode-fake-node]
   -f, --fake-node-name <NODE_NAME>
-          Name for fake node [default: fake.os]
+          Name for fake node [default: fake.dev]
   -c, --fakechain-port <FAKECHAIN_PORT>
           The port to run the fakechain on (or to connect to) [default: 8545]
       --rpc <RPC_ENDPOINT>
@@ -116,7 +116,7 @@ Path to place fake node home directory at; defaults to `/tmp/kinode-fake-node`.
 
 short: `-f`
 
-The name of the fake node; defaults to `fake.os`.
+The name of the fake node; defaults to `fake.dev`.
 
 ### `--fakechain-port`
 

--- a/src/kit/inject-message.md
+++ b/src/kit/inject-message.md
@@ -3,13 +3,14 @@
 `kit inject-message` injects the given message to the node running at given port/URL, e.g.,
 
 ```
-kit inject-message foo:foo:template.os '{"Send": {"target": "fake2.os", "message": "hello world"}}'
+kit inject-message foo:foo:template.os '{"Send": {"target": "fake2.dev", "message": "hello world"}}'
 ```
 
 ## Discussion
 
 `kit inject-message` injects the given message into the given node.
 It is useful for:
+
 1. Testing processes from the outside world during development
 2. Injecting data into the node
 3. Combining the above with `bash` or other scripting.
@@ -69,10 +70,10 @@ short: `-n`
 
 Node to target (i.e. the node portion of the address).
 
-E.g., the following, sent to the port running `fake.os`, will be forwarded from `fake.os`'s HTTP server to `fake2@foo:foo:template.os`:
+E.g., the following, sent to the port running `fake.dev`, will be forwarded from `fake.dev`'s HTTP server to `fake2.dev@foo:foo:template.os`:
 
 ``` bash
-kit inject-message foo:foo:template.os '{"Send": {"target": "fake.os", "message": "wow, it works!"}}' --node fake2.os
+kit inject-message foo:foo:template.dev '{"Send": {"target": "fake.dev", "message": "wow, it works!"}}' --node fake2.dev
 ```
 
 ### `--blob`

--- a/src/kit/run-tests.md
+++ b/src/kit/run-tests.md
@@ -79,7 +79,6 @@ For example:
 runtime = { FetchVersion = "latest" }
 ```
 
-
 ### `runtime_build_release`
 
 If given `runtime = RepoPath`, `runtime_build_release` decides whether to build the runtime as `--release` or not.
@@ -89,7 +88,6 @@ For example:
 ```toml
 runtime_build_release = true
 ```
-
 
 ### `tests`
 
@@ -108,6 +106,7 @@ Key                     | Value Type      | Value Description
 Each test package is [a single-process package that accepts and responds with certain messages](#test-package-format).
 
 For example:
+
 ```toml
 [[tests]]
 setup_package_paths = ["chat"]
@@ -126,7 +125,6 @@ network_router = { port = 9001, defects = "None" }
 [[tests.nodes]]
 ...
 ```
-
 
 #### `nodes`
 
@@ -150,16 +148,15 @@ For example:
 [[tests.nodes]]
 port = 8080
 home = "home/first"
-fake_node_name = "first.os"
+fake_node_name = "first.dev"
 runtime_verbosity = 0
 
 [[tests.nodes]]
 port = 8081
 home = "home/second"
-fake_node_name = "second.os"
+fake_node_name = "second.dev"
 runtime_verbosity = 0
 ```
-
 
 ## Test Package Interface
 

--- a/src/my_first_app/chapter_1.md
+++ b/src/my_first_app/chapter_1.md
@@ -82,10 +82,12 @@ The files in the `pkg/` directory are injected into the Kinode with [`kit start-
 
 Though not included in this template, packages with a frontend have a `ui/` directory as well.
 For an example, look at the result of:
+
 ```bash
 kit new my_chat_app_with_ui --ui
 tree my_chat_app_with_ui
 ```
+
 Note that not all templates have a UI-enabled version.
 As of 240118, only the Rust chat template has a UI-enabled version.
 
@@ -134,8 +136,9 @@ The `metadata.json` file contains ERC721 compatible metadata about the package.
 The only required fields are `package_name`, `current_version`, and `publisher`, which are filled in with default values:
 
 ```bash
-$ cat my_chat_app/metadata.json
+cat my_chat_app/metadata.json
 ```
+
 ```json
 {
     "name": "my_chat_app",
@@ -154,6 +157,7 @@ $ cat my_chat_app/metadata.json
     "animation_url": ""
 }
 ```
+
 Here, the `publisher` is some default value, but for a real package, this field should contain the KNS id of the publishing node.
 The `publisher` can also be set with a `kit new --publisher` flag.
 The rest of these fields are not required for development, but become important when publishing a package with the `app_store`.
@@ -265,7 +269,7 @@ Congratulations: you've now built and installed your first application on Kinode
 To test out the functionality of `my_chat_app`, spin up another fake node to chat with in a new terminal:
 
 ```bash
-kit boot-fake-node -h /tmp/kinode-fake-node-2 -p 8081 -f fake2.os
+kit boot-fake-node -h /tmp/kinode-fake-node-2 -p 8081 -f fake2.dev
 ```
 
 The fake nodes communicate over a mocked local network.
@@ -285,20 +289,20 @@ kit start-package -p 8081
 To send a chat message from the first node, run the following in its terminal:
 
 ```
-m our@my_chat_app:my_chat_app:template.os '{"Send": {"target": "fake2.os", "message": "hello world"}}'
+m our@my_chat_app:my_chat_app:template.os '{"Send": {"target": "fake2.dev", "message": "hello world"}}'
 ```
 
 and replying, from the other terminal:
 
 ```
-m our@my_chat_app:my_chat_app:template.os '{"Send": {"target": "fake.os", "message": "wow, it works!"}}'
+m our@my_chat_app:my_chat_app:template.os '{"Send": {"target": "fake.dev", "message": "wow, it works!"}}'
 ```
 
 Messages can also be injected from the outside.
 From a bash terminal, use `kit inject-message`, like so:
 
 ```bash
-kit inject-message my_chat_app:my_chat_app:template.os '{"Send": {"target": "fake2.os", "message": "hello from the outside world"}}'
-kit inject-message my_chat_app:my_chat_app:template.os '{"Send": {"target": "fake.os", "message": "replying from fake2.os using first method..."}}' --node fake2.os
-kit inject-message my_chat_app:my_chat_app:template.os '{"Send": {"target": "fake.os", "message": "and second!"}}' -p 8081
+kit inject-message my_chat_app:my_chat_app:template.os '{"Send": {"target": "fake2.dev", "message": "hello from the outside world"}}'
+kit inject-message my_chat_app:my_chat_app:template.os '{"Send": {"target": "fake.dev", "message": "replying from fake2.devs using first method..."}}' --node fake2.dev
+kit inject-message my_chat_app:my_chat_app:template.os '{"Send": {"target": "fake.dev", "message": "and second!"}}' -p 8081
 ```

--- a/src/process/processes.md
+++ b/src/process/processes.md
@@ -7,6 +7,7 @@ The Kinode runtime handles message-passing between processes, plus the startup a
 This section describes the message design as it relates to processes.
 
 Each process instance has a globally unique identifier, or `Address`, composed of four elements.
+
 - the publisher's node
 - the package name (not to be confused with `PackageId`)
 - the process name (not to be confused with `ProcessId`). Processes spawn with their own identifier (`process_name`): either a developer-selected string or a randomly-generated number as string.
@@ -15,12 +16,14 @@ Each process instance has a globally unique identifier, or `Address`, composed o
 The way these elements compose is the following:
 
 [Package IDs](https://docs.rs/kinode_process_lib/latest/kinode_process_lib/struct.PackageId.html) look like:
+
 ```
 [package_name]:[publisher_node]
 my_cool_software:publisher_node.os
 ```
 
 [Process IDs](https://docs.rs/kinode_process_lib/latest/kinode_process_lib/kinode/process/standard/struct.ProcessId.html) look like:
+
 ```
 [process_name]:[package_name]:[publisher_node]
 process_one:my_cool_software:publisher_node.os
@@ -31,7 +34,7 @@ process_one:my_cool_software:publisher_node.os
 
 ```
 [node]@[process_name]:[package_name]:[publisher_node]
-some_user.os@process_one:my_cool_software:publisher_node.os
+some_user.dev@process_one:my_cool_software:publisher_node.os
 ```
 
 Processes are compiled to Wasm.
@@ -91,8 +94,9 @@ There is one other use of inheritance, discussed below: [passing data in request
 
 When sending a request, a process can await a response to that specific request, queueing other messages in the meantime.
 Awaiting a response leads to easier-to-read code:
-* The response is handled in the next line of code, rather than in a separate iteration of the message-handling loop
-* Therefore, the `context` need not be set.
+
+- The response is handled in the next line of code, rather than in a separate iteration of the message-handling loop
+- Therefore, the `context` need not be set.
 
 The downside of awaiting a response is that all other messages to a process will be queued until that response is received and handled.
 As such, certain applications lend themselves to blocking with an await, and others don't.
@@ -132,6 +136,7 @@ If process B does not attach a new `lazy_load_blob` to that inheriting message, 
 For example, consider again the file-transfer process discussed [above](#awaiting-a-response).
 Say one node, `send.os`, is transferring a file to another node, `recv.os`.
 The process of sending a file chunk will look something like:
+
 1. `recv.os` sends a request for chunk N
 2. `send.os` receives the request and itself makes a request to the filesystem for the piece of the file
 3. `send.os` receives a response from the filesystem with the piece of the file in the `lazy_load_blob`;
@@ -166,6 +171,7 @@ A process can spawn "child" processes — in which case the spawner is known as 
 As discussed [above](#awaiting-a-response), one of the primary reasons to write an application with multiple processes is to enable both simple code and high performance.
 
 Child processes can be used to:
+
 1. Run code that may crash without risking crashing the parent
 2. Run compute-heavy code without blocking the parent
 3. Run IO-heavy code without blocking the parent
@@ -186,7 +192,6 @@ The details of this are not covered in the Kinode Book, but can be found in the 
 Wasm runs modules by default, or components, as described [here](https://component-model.bytecodealliance.org/design/why-component-model.html): components are just modules that follow some specific format.
 Kinode processes are Wasm components that have certain imports and exports so they can be run by Kinode OS.
 Pragmatically, processes can be compiled using the [`kit` tools](https://github.com/kinode-dao/kit).
-
 
 The long term goal of Kinode is, using [WASI](https://wasi.dev/), to provide a secure, sandboxed environment for Wasm components to make use of the kernel features described in this document.
 Further, Kinode has a Virtual File System ([VFS](../files.md)) which processes can interact with to access files on a user's machine, and in the future WASI could also expose access to the filesystem for Wasm components directly.

--- a/src/terminal.md
+++ b/src/terminal.md
@@ -8,22 +8,23 @@ All commands in the [terminal](https://github.com/kinode-dao/kinode/tree/main/ki
 Kinode OS comes pre-loaded with a number of scripts useful for debugging and everyday use.
 These scripts are fully named `<SCRIPT>:terminal:sys` e.g `hi:terminal:sys`, but the distro [aliases](#alias---alias-a-script-name) these to short names, in this case just `hi`, for convenience.
 
-
 ### `hi` - ping another kinode
+
 ```bash
 Usage: hi <KNS_ID> <MESSAGE>
 Arguments:
-  <KNS_ID>  id of the node you want to message, e.g. some-node.os
+  <KNS_ID>  id of the node you want to message, e.g. some-node.dev
   <MESSAGE> any string
 Example:
-hi other-node.os Hello other-node.os! how are you?
+hi other-node.dev Hello other-node.dev! how are you?
 ```
 
 ### `m` - message a process
+
 ```bash
 Usage: m <ADDRESS> <BODY>
 Arguments:
-  <ADDRESS> kns addresss e.g. some-node.os@process:pkg:publisher.os
+  <ADDRESS> kns addresss e.g. some-node.dev@process:pkg:publisher.dev
   <BODY>    json payload wrapped in single quotes, e.g. '{"foo": "bar"}'
 Options:
   -a, --await <SECONDS> await the response, timing out after SECONDS
@@ -35,6 +36,7 @@ Example:
 ```
 
 ### `top` - display information about processes
+
 ```bash
 Usage: top [PROCESS_ID]
 Arguments:
@@ -47,19 +49,21 @@ Example:
 ```
 
 ### `alias` - alias a script name
+
 ```bash
 Usage: alias <NAME> [SCRIPT]
 Arguments:
   <NAME>   the name you want to assign the script to
   [SCRIPT] the script-id
 Example:
-  alias my-script my-script:my-package:my-name.os
+  alias my-script my-script:my-package:my-name.dev
     - this lets you call my-script in the terminal as a shorthand
   alias my-script
     - this removes the my-script alias
 ```
 
 ### `cat` - print the contents of a file in your vfs
+
 ```bash
 Usage: cat <FILE_PATH>
 Arguments:
@@ -69,7 +73,9 @@ Example:
 ```
 
 ### `echo` - print the argument
+
 `echo` is mostly an example script for developers to look at.
+
 ```bash
 Usage: echo <MESSAGE>
 Arguments:
@@ -81,6 +87,7 @@ Example:
 For more information on writing your own scripts, see the [cookbook](./cookbook/writing_scripts.md).
 
 ## Packaging Scripts with `scripts.json`
+
 For your scripts to be usable by the terminal, you must include a `pkg/scripts.json` file, like [this one](https://github.com/kinode-dao/kinode/blob/main/kinode/packages/terminal/pkg/scripts.json).
 Note that this is a core package and this file should not be edited, but rather you should create one in your own package.
 For more discussion on package folder structure, look [here](https://book.kinode.org/my_first_app/chapter_1.html#exploring-the-package).
@@ -103,7 +110,9 @@ Processes may not necessarily use all these fields.
 For instance, "m.wasm" only uses root, public, and `request_networking`, omitting `request_capabilities` and `grant_capabilities`.
 
 ### Example
+
 This is a `scripts.json` that publishes a single script, `hi`, which doesn't receive `root` capabilities, is not `public`, can send messages over the network, will receive the capability to message `net:distro:sys`, and gives `net:distro:sys` the ability to message it back:
+
 ```json
 {
     "hi.wasm": {


### PR DESCRIPTION
Initial pass, changed in applicable locations where one might be developing with `kit f`. 

I feel changing it in the general explainer docs might confuse people as mainnet currently is purely .os. 

Warming up to potentially making `kit f` purely .os again