### PR TITLE
section 9 clarify

### DIFF
--- a/src/hosted-nodes.md
+++ b/src/hosted-nodes.md
@@ -74,11 +74,16 @@ HTTP requests routed to that local port will then appear to the remote host as o
 
 Create a SSH tunnel like so (again, replacing [assumed values with those in your `advanced details`](#accessing-your-kinodes-terminal)):
 ```bash
+ssh -L 9090:localhost:<HTTP port> <SSH address> -f -N
+```
+e.g.,
+``` bash
 ssh -L 9090:localhost:8099 kexampleuser@template.hosting.kinode.net -f -N
 ```
+
 or, if you've added your host to your [`~/.ssh/config`](#ssh-config),
 ```bash
-ssh -L 9090:localhost:8099 template -f -N
+ssh -L 9090:localhost:<HTTP port> <Host> -f -N
 ```
 
 Now, `kit` requests sent to `9090` will be routed to the remote Kinode, e.g.,
@@ -86,3 +91,5 @@ Now, `kit` requests sent to `9090` will be routed to the remote Kinode, e.g.,
 kit s foo -p 9090
 ```
 will function the same as for a locally-hosted Kinode.
+
+You will need to create an SSH tunnel each time you start a session.


### PR DESCRIPTION
- @jonathan (dont know your github tag)

line 95: i know ssh tunnel needs to be recreated every once in a while, but i'm not sure is it every terminal session, or dev session, or how exactly to specify it

- can you make a copy pasteable link in the hosting, and then we can modify the instructions to reflect that
- can you write a command to check if the hosting tunnel is correctly set? or was it to check something in the browser?